### PR TITLE
Fix Orders service endpoint used by Checkout service in Kubernetes

### DIFF
--- a/deploy/kubernetes/kustomize/base/checkout/configMap.yaml
+++ b/deploy/kubernetes/kustomize/base/checkout/configMap.yaml
@@ -4,3 +4,4 @@ metadata:
   name: checkout
 data:
   REDIS_URL: redis://checkout-redis:6379
+  ENDPOINTS_ORDERS: http://orders.orders-prod.svc:80


### PR DESCRIPTION
In Kubernetes checkout deployment should use proper orders endpoint, currently it is defaulting to stubbed behavior.