### PR TITLE
Setting to control ui service keep alives

### DIFF
--- a/src/ui/src/main/java/com/amazon/sample/ui/config/Clients.java
+++ b/src/ui/src/main/java/com/amazon/sample/ui/config/Clients.java
@@ -65,12 +65,16 @@ public class Clients {
     @Value("${endpoints.logging}")
     private boolean logging;
 
+    @Value("${endpoints.http.keep-alive}")
+    private boolean keepAlive;
+
     private WebClient createWebClient(ObjectMapper mapper, WebClient.Builder webClientBuilder) {
         TcpClient tcpClient = TcpClient.create()
                 .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, 1000) // Connection Timeout
                 .doOnConnected(connection ->
                         connection.addHandlerLast(new ReadTimeoutHandler(10)) // Read Timeout
                                 .addHandlerLast(new WriteTimeoutHandler(10))); // Write Timeout
+
         ExchangeStrategies strategies = ExchangeStrategies
                 .builder()
                 .codecs(clientDefaultCodecsConfigurer -> {
@@ -79,7 +83,7 @@ public class Clients {
                 }).build();
 
         return webClientBuilder
-                .clientConnector(new ReactorClientHttpConnector(HttpClient.from(tcpClient)))
+                .clientConnector(new ReactorClientHttpConnector(HttpClient.from(tcpClient).keepAlive(keepAlive)))
                 .exchangeStrategies(strategies)
                 .filters( exchangeFilterFunctions -> {
                     if(logging) {

--- a/src/ui/src/main/resources/application.yml
+++ b/src/ui/src/main/resources/application.yml
@@ -10,14 +10,14 @@ endpoints:
   assets: false #http://localhost:8084
   checkout:  false #http://localhost:8085
   logging: false
+  http:
+    keep-alive: true
 
 retail:
   ui:
     metadata:
       region: "none"
     banner: ""
-
-
 
 management:
   endpoints:


### PR DESCRIPTION
There are some situations where disabling HTTP keep alive on calls to the downstream services is desirable, for example for demonstrating situations where its necessary to get better traffic distribution to multiple targets.

This adds a setting the ui service that gives control over whether it enables HTTP keep alive on calls to downstream services. HTTP keep alive is enabled by default, but can be disabled by setting the environment variable `ENDPOINTS_HTTP_KEEPALIVE=false`.