### PR TITLE
chore: Dependencies - RDS/MQ/ElastiCache/DDB

### DIFF
--- a/terraform/lib/dependencies/catalog_rds.tf
+++ b/terraform/lib/dependencies/catalog_rds.tf
@@ -10,8 +10,8 @@ module "catalog_rds" {
     one = {}
   }
 
-  vpc_id = module.vpc.inner.vpc_id
-  subnets = module.vpc.inner.private_subnets
+  vpc_id = var.vpc_id
+  subnets = var.subnet_ids
 
   allowed_security_groups = [aws_security_group.catalog_rds_ingress.id]
 
@@ -30,7 +30,7 @@ module "catalog_rds" {
   db_cluster_parameter_group_name   = "${var.environment_name}-catalog"
   db_cluster_parameter_group_family = "aurora-mysql5.7"
 
-  tags             = module.tags.result
+  tags             = var.tags
 }
 
 resource "random_string" "catalog_db_master" {
@@ -41,20 +41,7 @@ resource "random_string" "catalog_db_master" {
 resource "aws_security_group" "catalog_rds_ingress" {
   name        = "${var.environment_name}-catalog-db"
   description = "Allow inbound traffic to catalog MySQL"
-  vpc_id      = module.vpc.inner.vpc_id
+  vpc_id      = var.vpc_id
 
-  tags             = module.tags.result
-}
-
-module "rds_vpc" {
-  source = "../vpc"
-
-  environment_name = var.environment_name
-  tags             = module.tags.result
-}
-
-module "rds_tags" {
-  source = "../tags"
-
-  environment_name = var.environment_name
+  tags             = var.tags
 }

--- a/terraform/lib/dependencies/dynamodb.tf
+++ b/terraform/lib/dependencies/dynamodb.tf
@@ -22,12 +22,6 @@ module "dynamodb-carts" {
             projection_type = "ALL"
         }
     ]
-    
-    tags             = module.tags.result
-}
 
-module "ddb_tags" {
-  source = "../tags"
-
-  environment_name = var.environment_name
+    tags             = var.tags
 }

--- a/terraform/lib/dependencies/dynamodb.tf
+++ b/terraform/lib/dependencies/dynamodb.tf
@@ -22,5 +22,12 @@ module "dynamodb-carts" {
             projection_type = "ALL"
         }
     ]
+    
+    tags             = module.tags.result
+}
 
+module "ddb_tags" {
+  source = "../tags"
+
+  environment_name = var.environment_name
 }

--- a/terraform/lib/dependencies/dynamodb.tf
+++ b/terraform/lib/dependencies/dynamodb.tf
@@ -1,0 +1,26 @@
+module "dynamodb-carts" {
+    source = "terraform-aws-modules/dynamodb-table/aws"
+
+    name             = "${var.environment_name}-carts"
+    hash_key         = "id"
+
+    attributes = [
+        {
+            name = "id"
+            type = "S"
+        },
+        {
+            name = "customerId"
+            type = "S"
+        }
+    ]
+
+    global_secondary_indexes = [
+        {
+            name            = "idx_global_customerId"
+            hash_key        = "customerId"
+            projection_type = "ALL"
+        }
+    ]
+
+}

--- a/terraform/lib/dependencies/elasticache.tf
+++ b/terraform/lib/dependencies/elasticache.tf
@@ -1,0 +1,8 @@
+module "checkout-elasticache-redis" {
+  source  = "cloudposse/elasticache-redis/aws"
+  version = "0.48.0"
+
+  name              = "${var.environment_name}-elasticache-checkout"
+  vpc_id            = var.vpc_id
+  instance_type     = "cache.t3.micro"
+}

--- a/terraform/lib/dependencies/elasticache.tf
+++ b/terraform/lib/dependencies/elasticache.tf
@@ -3,6 +3,21 @@ module "checkout-elasticache-redis" {
   version = "0.48.0"
 
   name              = "${var.environment_name}-elasticache-checkout"
-  vpc_id            = var.vpc_id
+  vpc_id            = module.vpc.inner.vpc_id
   instance_type     = "cache.t3.micro"
+  subnets          = module.vpc.inner.private_subnets
+  tags             = module.tags.result
+}
+
+module "vpc" {
+  source = "../vpc"
+
+  environment_name = var.environment_name
+  tags             = module.tags.result
+}
+
+module "tags" {
+  source = "../tags"
+
+  environment_name = var.environment_name
 }

--- a/terraform/lib/dependencies/elasticache.tf
+++ b/terraform/lib/dependencies/elasticache.tf
@@ -3,21 +3,8 @@ module "checkout-elasticache-redis" {
   version = "0.48.0"
 
   name              = "${var.environment_name}-elasticache-checkout"
-  vpc_id            = module.vpc.inner.vpc_id
+  vpc_id            = var.vpc_id
   instance_type     = "cache.t3.micro"
-  subnets          = module.vpc.inner.private_subnets
-  tags             = module.tags.result
-}
-
-module "vpc" {
-  source = "../vpc"
-
-  environment_name = var.environment_name
-  tags             = module.tags.result
-}
-
-module "tags" {
-  source = "../tags"
-
-  environment_name = var.environment_name
+  subnets          = var.subnet_ids
+  tags             = var.tags
 }

--- a/terraform/lib/dependencies/mq.tf
+++ b/terraform/lib/dependencies/mq.tf
@@ -2,14 +2,31 @@ module "orders_mq_broker" {
     source = "cloudposse/mq-broker/aws"
 
     name                       = "${var.environment_name}_orders_mq-broker"
-    vpc_id                     = var.vpc_id
-    subnet_ids                 = var.subnets
+    vpc_id                     = module.vpc.inner.vpc_id
+    subnet_ids                 = [module.vpc.inner.private_subnets[0]]
     mq_admin_user              = ["orders_mq_user"]
     mq_admin_password          = [random_password.mq_password.result]
+    deployment_mode            = "SINGLE_INSTANCE"
+
+    tags             = module.tags.result
+
 }
 
 resource "random_password" "mq_password" {
   length           = 16
   special          = true
-  override_special = "!#$%&*()-_=+[]{}<>:?"
+  override_special = "!#$%&*()-_+{}<>?"
+}
+
+module "mq_vpc" {
+  source = "../vpc"
+
+  environment_name = var.environment_name
+  tags             = module.tags.result
+}
+
+module "mq_tags" {
+  source = "../tags"
+
+  environment_name = var.environment_name
 }

--- a/terraform/lib/dependencies/mq.tf
+++ b/terraform/lib/dependencies/mq.tf
@@ -1,0 +1,15 @@
+module "orders_mq_broker" {
+    source = "cloudposse/mq-broker/aws"
+
+    name                       = "${var.environment_name}_orders_mq-broker"
+    vpc_id                     = var.vpc_id
+    subnet_ids                 = var.subnets
+    mq_admin_user              = ["orders_mq_user"]
+    mq_admin_password          = [random_password.mq_password.result]
+}
+
+resource "random_password" "mq_password" {
+  length           = 16
+  special          = true
+  override_special = "!#$%&*()-_=+[]{}<>:?"
+}

--- a/terraform/lib/dependencies/mq.tf
+++ b/terraform/lib/dependencies/mq.tf
@@ -2,13 +2,13 @@ module "orders_mq_broker" {
     source = "cloudposse/mq-broker/aws"
 
     name                       = "${var.environment_name}_orders_mq-broker"
-    vpc_id                     = module.vpc.inner.vpc_id
-    subnet_ids                 = [module.vpc.inner.private_subnets[0]]
+    vpc_id                     = var.vpc_id
+    subnet_ids                 = [var.subnet_ids[0]]
     mq_admin_user              = ["orders_mq_user"]
     mq_admin_password          = [random_password.mq_password.result]
     deployment_mode            = "SINGLE_INSTANCE"
 
-    tags             = module.tags.result
+    tags             = var.tags
 
 }
 
@@ -16,17 +16,4 @@ resource "random_password" "mq_password" {
   length           = 16
   special          = true
   override_special = "!#$%&*()-_+{}<>?"
-}
-
-module "mq_vpc" {
-  source = "../vpc"
-
-  environment_name = var.environment_name
-  tags             = module.tags.result
-}
-
-module "mq_tags" {
-  source = "../tags"
-
-  environment_name = var.environment_name
 }

--- a/terraform/lib/dependencies/orders_rds.tf
+++ b/terraform/lib/dependencies/orders_rds.tf
@@ -1,0 +1,47 @@
+module "orders_rds" {
+  source  = "terraform-aws-modules/rds-aurora/aws"
+
+  name = "${var.environment_name}-orders"
+  engine = "aurora-mysql"
+  engine_version = "5.7"
+  instance_class = "db.t3.small"
+
+  instances = {
+    one = {}
+  }
+
+  vpc_id = var.vpc_id
+  subnets = var.subnet_ids
+
+  allowed_security_groups = [aws_security_group.orders_rds_ingress.id]
+
+  master_password        = random_string.orders_db_master.result
+  create_random_password = false
+  database_name          = "orders"
+  storage_encrypted      = true
+  apply_immediately      = true
+  skip_final_snapshot    = true
+
+  create_db_parameter_group = true
+  db_parameter_group_name   = "${var.environment_name}-orders"
+  db_parameter_group_family = "aurora-mysql5.7"
+
+  create_db_cluster_parameter_group = true
+  db_cluster_parameter_group_name   = "${var.environment_name}-orders"
+  db_cluster_parameter_group_family = "aurora-mysql5.7"
+
+  tags             = var.tags
+}
+
+resource "random_string" "orders_db_master" {
+  length  = 10
+  special = false
+}
+
+resource "aws_security_group" "orders_rds_ingress" {
+  name        = "${var.environment_name}-orders-db"
+  description = "Allow inbound traffic to orders MySQL"
+  vpc_id      = var.vpc_id
+
+  tags             = var.tags
+}

--- a/terraform/lib/dependencies/outputs.tf
+++ b/terraform/lib/dependencies/outputs.tf
@@ -1,0 +1,82 @@
+output "cluster_endpoint" {
+  description = "Writer endpoint for the cluster"
+  value       = module.catalog_rds.cluster_endpoint
+}
+
+output "cluster_master_password" {
+  description = "The database master password"
+  value       = module.catalog_rds.cluster_master_password
+  sensitive   = true
+}
+
+output "cluster_master_username" {
+  description = "The database master username"
+  value       = module.catalog_rds.cluster_master_username
+  sensitive   = true
+}
+
+output "cluster_port" {
+  description = "The database port"
+  value       = module.catalog_rds.cluster_port
+}
+
+output "cluster_reader_endpoint" {
+  description = "A read-only endpoint for the cluster, automatically load-balanced across replicas"
+  value       = module.catalog_rds.cluster_reader_endpoint
+}
+
+output "cluster_arn" {
+  description = "Amazon Resource Name (ARN) of cluster"
+  value       = module.catalog_rds.cluster_arn
+}
+
+output "dynamodb_table_arn" {
+  description = "ARN of the DynamoDB table"
+  value       = module.dynamodb-carts.dynamodb_table_arn
+}
+
+output "dynamodb_table_id" {
+  description = "ID of the DynamoDB table"
+  value       = module.dynamodb-carts.dynamodb_table_id
+}
+
+output "broker_id" {
+  value       = module.orders_mq_broker.broker_id
+  description = "AmazonMQ broker ID"
+}
+
+output "broker_arn" {
+  value       = module.orders_mq_broker.broker_arn
+  description = "AmazonMQ broker ARN"
+}
+
+output "primary_console_url" {
+  value       = module.orders_mq_broker.primary_console_url
+  description = "AmazonMQ active web console URL"
+}
+
+output mq_passsword {
+  value     = random_password.mq_password.result
+  sensitive = true
+  description = "AmazonMQ Admin password."
+}
+
+output checkout_elasticache_arn {
+    value = module.checkout-elasticache-redis.arn
+    description = "Checkout Redis ElastiCache ARN."
+}
+
+output checkout_elasticache_primary_endpoint {
+    value = module.checkout-elasticache-redis.endpoint
+    description = "Checkout Redis hostname."
+}
+
+output checkout_elasticache_reader_endpoint {
+    value = module.checkout-elasticache-redis.reader_endpoint_address
+    description = "Checkout Redis hostname."
+}
+
+output checkout_elasticache_port {
+    value = module.checkout-elasticache-redis.port
+    description = "Checkout Redis port."
+}

--- a/terraform/lib/dependencies/outputs.tf
+++ b/terraform/lib/dependencies/outputs.tf
@@ -1,82 +1,114 @@
-output "cluster_endpoint" {
+output "catalog_cluster_endpoint" {
   description = "Writer endpoint for the cluster"
   value       = module.catalog_rds.cluster_endpoint
 }
 
-output "cluster_master_password" {
+output "catalog_cluster_master_password" {
   description = "The database master password"
   value       = module.catalog_rds.cluster_master_password
   sensitive   = true
 }
 
-output "cluster_master_username" {
+output "catalog_cluster_master_username" {
   description = "The database master username"
   value       = module.catalog_rds.cluster_master_username
   sensitive   = true
 }
 
-output "cluster_port" {
+output "catalog_cluster_port" {
   description = "The database port"
   value       = module.catalog_rds.cluster_port
 }
 
-output "cluster_reader_endpoint" {
+output "catalog_cluster_reader_endpoint" {
   description = "A read-only endpoint for the cluster, automatically load-balanced across replicas"
   value       = module.catalog_rds.cluster_reader_endpoint
 }
 
-output "cluster_arn" {
+output "catalog_cluster_arn" {
   description = "Amazon Resource Name (ARN) of cluster"
   value       = module.catalog_rds.cluster_arn
 }
 
-output "dynamodb_table_arn" {
+output "orders_cluster_endpoint" {
+  description = "Writer endpoint for the cluster"
+  value       = module.orders_rds.cluster_endpoint
+}
+
+output "orders_cluster_master_password" {
+  description = "The database master password"
+  value       = module.orders_rds.cluster_master_password
+  sensitive   = true
+}
+
+output "orders_cluster_master_username" {
+  description = "The database master username"
+  value       = module.orders_rds.cluster_master_username
+  sensitive   = true
+}
+
+output "orders_cluster_port" {
+  description = "The database port"
+  value       = module.orders_rds.cluster_port
+}
+
+output "orders_cluster_reader_endpoint" {
+  description = "A read-only endpoint for the cluster, automatically load-balanced across replicas"
+  value       = module.orders_rds.cluster_reader_endpoint
+}
+
+output "orders_cluster_arn" {
+  description = "Amazon Resource Name (ARN) of cluster"
+  value       = module.orders_rds.cluster_arn
+}
+
+output "carts_dynamodb_table_arn" {
   description = "ARN of the DynamoDB table"
   value       = module.dynamodb-carts.dynamodb_table_arn
 }
 
-output "dynamodb_table_id" {
+output "carts_dynamodb_table_id" {
   description = "ID of the DynamoDB table"
   value       = module.dynamodb-carts.dynamodb_table_id
 }
 
-output "broker_id" {
+output "orders_broker_id" {
   value       = module.orders_mq_broker.broker_id
   description = "AmazonMQ broker ID"
 }
 
-output "broker_arn" {
+output "orders_broker_arn" {
   value       = module.orders_mq_broker.broker_arn
   description = "AmazonMQ broker ARN"
 }
 
-output "primary_console_url" {
+output "orders_mq_primary_console_url" {
   value       = module.orders_mq_broker.primary_console_url
   description = "AmazonMQ active web console URL"
 }
 
-output mq_passsword {
+output "orders_mq_passsword" {
   value     = random_password.mq_password.result
   sensitive = true
   description = "AmazonMQ Admin password."
 }
 
-output checkout_elasticache_arn {
+output "checkout_elasticache_arn" {
     value = module.checkout-elasticache-redis.arn
     description = "Checkout Redis ElastiCache ARN."
 }
 
-output checkout_elasticache_primary_endpoint {
+output "checkout_elasticache_primary_endpoint" {
     value = module.checkout-elasticache-redis.endpoint
     description = "Checkout Redis hostname."
 }
 
-output checkout_elasticache_reader_endpoint {
+output "checkout_elasticache_reader_endpoint" {
     value = module.checkout-elasticache-redis.reader_endpoint_address
     description = "Checkout Redis hostname."
 }
 
-output checkout_elasticache_port {
+output "checkout_elasticache_port" {
     value = module.checkout-elasticache-redis.port
     description = "Checkout Redis port."
 }

--- a/terraform/lib/dependencies/rds.tf
+++ b/terraform/lib/dependencies/rds.tf
@@ -1,0 +1,47 @@
+module "catalog_rds" {
+  source  = "terraform-aws-modules/rds-aurora/aws"
+
+  name = "${var.environment_name}-catalog"
+  engine = "aurora-mysql"
+  engine_version = "5.7"
+  instance_class = "db.t3.small"
+
+  instances = {
+    one = {}
+  }
+
+  vpc_id = var.vpc_id
+  subnets = var.subnets
+
+  allowed_security_groups = [aws_security_group.catalog_rds_ingress.id]
+
+  master_password        = random_string.catalog_db_master.result
+  create_random_password = false
+  database_name          = "catalog"
+  storage_encrypted      = true
+  apply_immediately      = true
+  skip_final_snapshot    = true
+
+  create_db_parameter_group = true
+  db_parameter_group_name   = "${var.environment_name}-catalog"
+  db_parameter_group_family = "aurora-mysql5.7"
+
+  create_db_cluster_parameter_group = true
+  db_cluster_parameter_group_name   = "${var.environment_name}-catalog"
+  db_cluster_parameter_group_family = "aurora-mysql5.7"
+
+  # tags = local.tags
+}
+
+resource "random_string" "catalog_db_master" {
+  length  = 10
+  special = false
+}
+
+resource "aws_security_group" "catalog_rds_ingress" {
+  name        = "${var.environment_name}-catalog-db"
+  description = "Allow inbound traffic to catalog MySQL"
+  vpc_id      = var.vpc_id
+
+  # tags = local.tags
+}

--- a/terraform/lib/dependencies/rds.tf
+++ b/terraform/lib/dependencies/rds.tf
@@ -10,8 +10,8 @@ module "catalog_rds" {
     one = {}
   }
 
-  vpc_id = var.vpc_id
-  subnets = var.subnets
+  vpc_id = module.vpc.inner.vpc_id
+  subnets = module.vpc.inner.private_subnets
 
   allowed_security_groups = [aws_security_group.catalog_rds_ingress.id]
 
@@ -30,7 +30,7 @@ module "catalog_rds" {
   db_cluster_parameter_group_name   = "${var.environment_name}-catalog"
   db_cluster_parameter_group_family = "aurora-mysql5.7"
 
-  # tags = local.tags
+  tags             = module.tags.result
 }
 
 resource "random_string" "catalog_db_master" {
@@ -41,7 +41,20 @@ resource "random_string" "catalog_db_master" {
 resource "aws_security_group" "catalog_rds_ingress" {
   name        = "${var.environment_name}-catalog-db"
   description = "Allow inbound traffic to catalog MySQL"
-  vpc_id      = var.vpc_id
+  vpc_id      = module.vpc.inner.vpc_id
 
-  # tags = local.tags
+  tags             = module.tags.result
+}
+
+module "rds_vpc" {
+  source = "../vpc"
+
+  environment_name = var.environment_name
+  tags             = module.tags.result
+}
+
+module "rds_tags" {
+  source = "../tags"
+
+  environment_name = var.environment_name
 }

--- a/terraform/lib/dependencies/variables.tf
+++ b/terraform/lib/dependencies/variables.tf
@@ -1,14 +1,21 @@
 variable "environment_name" {
-  # default = "test"
+  type = string
 }
 
 variable "vpc_id" {
   type = string
-  # default = "vpc-e4678d9f"
 }
 
-variable "subnets" {
+variable "subnet_ids" {
   description = "List of subnet IDs used by database subnet group created"
   type        = list(string)
-  # default = ["subnet-07d7fba3c2caa131b", "subnet-865eb9da"]
+}
+
+variable "tags" {
+  description = "A map of tags to add to all resources"
+  default     = {}
+}
+
+variable "availability_zones" {
+  type = list(string)
 }

--- a/terraform/lib/dependencies/variables.tf
+++ b/terraform/lib/dependencies/variables.tf
@@ -1,18 +1,14 @@
 variable "environment_name" {
+  # default = "test"
 }
 
 variable "vpc_id" {
   type = string
+  # default = "vpc-e4678d9f"
 }
 
-variable "subnet_ids" {
-  type = list(string)
-}
-
-variable "availability_zones" {
-  type = list(string)
-}
-
-variable "tags" {
-  default = {}
+variable "subnets" {
+  description = "List of subnet IDs used by database subnet group created"
+  type        = list(string)
+  # default = ["subnet-07d7fba3c2caa131b", "subnet-865eb9da"]
 }


### PR DESCRIPTION
Adding the initial resources for the dependencies. Terraform apply can be ran from the `standalone` directory and the VPC module will be used to create the VPC and the required subnets. 