### PR TITLE
chore: Add e2e tests for Kubernetes using kind

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -84,6 +84,8 @@ jobs:
         kind load docker-image public.ecr.aws/aws-containers/retail-store-sample-ui:$IMAGE_TAG
 
         (cd deploy/kubernetes/charts && helmfile apply --wait)
+        
+        sleep 60
 
         cat <<EOF | kubectl apply -f -
         apiVersion: v1

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,11 +1,17 @@
 name: E2E Test
 
 on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
   workflow_dispatch:
 
 jobs:
-  build:
-    name: Run E2E Tests
+  docker:
+    name: Docker E2E Tests
     runs-on: ubuntu-latest
     steps:
     - name: Check out code
@@ -27,10 +33,75 @@ jobs:
 
     - name: Build Images
       run: |
-        scripts/build-image.sh -r 'public.ecr.aws/aws-containers' -t e2e --actions-cache
+        scripts/build-image.sh -r 'public.ecr.aws/aws-containers' -t e2e
         
     - name: Run Tests
       run: |
         (cd deploy/docker-compose && TAG=e2e MYSQL_PASSWORD='test123' docker-compose up -d)
-        (cd src/e2e && bash ./scripts/run-docker.sh -n docker-compose_default 'http://ui:8080')
+        (bash scripts/e2e-compose.sh)
         (cd deploy/docker-compose && docker-compose down)
+
+  kubernetes:
+    name: Kubernetes E2E Tests
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v3
+
+    - name: Set up Docker Buildx
+      id: e2e-buildx
+      uses: docker/setup-buildx-action@v2
+
+    - name: Set up QEMU
+      id: e2e-qemu
+      uses: docker/setup-qemu-action@v2
+      with:
+        image: tonistiigi/binfmt:latest
+        platforms: all
+
+    - name: Build Images
+      run: |
+        scripts/build-image.sh -r 'public.ecr.aws/aws-containers' -t e2e
+
+    - name: Setup helmfile
+      uses: mamezou-tech/setup-helmfile@v1.2.0
+
+    - name: Create k8s Kind Cluster
+      uses: helm/kind-action@v1.4.0
+      with:
+        cluster_name: kind
+        version: v0.17.0
+        
+    - name: Deploy
+      env:
+        IMAGE_TAG: e2e
+      run: |
+        kind load docker-image public.ecr.aws/aws-containers/retail-store-sample-assets:$IMAGE_TAG
+        kind load docker-image public.ecr.aws/aws-containers/retail-store-sample-catalog:$IMAGE_TAG
+        kind load docker-image public.ecr.aws/aws-containers/retail-store-sample-cart:$IMAGE_TAG
+        kind load docker-image public.ecr.aws/aws-containers/retail-store-sample-checkout:$IMAGE_TAG
+        kind load docker-image public.ecr.aws/aws-containers/retail-store-sample-orders:$IMAGE_TAG
+        kind load docker-image public.ecr.aws/aws-containers/retail-store-sample-ui:$IMAGE_TAG
+
+        (cd deploy/kubernetes/charts && helmfile apply --wait)
+
+        cat <<EOF | kubectl apply -f -
+        apiVersion: v1
+        kind: Service
+        metadata:
+          name: ui-nodeport
+        spec:
+          type: NodePort
+          selector:
+            app.kubernetes.io/name: ui
+            app.kubernetes.io/instance: ui
+            app.kubernetes.io/component: service
+          ports:
+            - port: 80
+              targetPort: http
+              nodePort: 30000
+        EOF
+
+    - name: Test
+      run: |
+        bash scripts/e2e-kind.sh

--- a/scripts/e2e-kind.sh
+++ b/scripts/e2e-kind.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -euo pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+cd $DIR/../src/e2e && bash ./scripts/run-docker.sh -n kind 'http://kind-control-plane:30000'

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+endpoint=$1
+
+if [ -z "$endpoint" ]; then
+  echo "Error: First argument must be endpoint (example: http://myendpoint:3000)"
+  exit 1
+fi
+
+set -euo pipefail
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+cd $DIR/../src/e2e && bash ./scripts/run-docker.sh $endpoint


### PR DESCRIPTION
Currently there are end-to-end tests for Docker that builds the container images, creates the container with Docker Compose and then runs the e2e test suite. This PR introduces the same mechanism for Kubernetes using kind.