### PR TITLE
feat: Add parameter to checkout service to add prefix to shipping option names

### DIFF
--- a/src/checkout/README.md
+++ b/src/checkout/README.md
@@ -1,0 +1,52 @@
+# AWS Containers Retail Sample - Checkout Service
+
+| Language | Persistence |
+|---|---|
+| Node | Redis |
+
+This service provides an API for storing customer data during the checkout process. Data is stored in Redis.
+
+## Configuration
+
+The following environment variables are available for configuring the service:
+
+| Name | Description | Default |
+|---|---|---|
+| `PORT` | The port which the server will listen on | `8080` |
+| `ENDPOINTS_ORDERS` | The endpoint of the orders API. If empty uses a mock implementation | `""` |
+| `REDIS_URL` | The endpoint of the Redis server used to write data. If empty use in-memory storage | `""` |
+| `REDIS_READER_URL` | The endpoint of the Redis server used to read data. If empty use the value of `REDIS_URL` | `""` |
+| `SHIPPING_NAME_PREFIX` | A string prefix that can be applied to the names of the shipping options | `""` |
+
+## Running
+
+There are two main options for running the service:
+
+### Local
+
+Pre-requisites:
+- Node.JS >= 16 installed
+
+Run the application like so:
+
+```
+yarn start
+```
+
+The API endpoint will be available at `http://localhost:8080`.
+
+### Docker
+
+A `docker-compose.yml` file is included to run the service in Docker:
+
+```
+docker compose up
+```
+
+The API endpoint will be available at `http://localhost:8080`.
+
+To clean up:
+
+```
+docker compose down
+```

--- a/src/checkout/src/checkout/checkout.module.ts
+++ b/src/checkout/src/checkout/checkout.module.ts
@@ -38,9 +38,10 @@ const orderServiceProvider = {
 
 const shippingServiceProvider = {
   provide: 'ShippingService',
-  useFactory: () => {
-    return new MockShippingService();
+  useFactory: (configService: ConfigService) => {
+    return new MockShippingService(configService.get('shipping.prefix'));
   },
+  inject: [ConfigService],
 };
 
 const repositoryProvider = {

--- a/src/checkout/src/checkout/shipping/MockShippingService.ts
+++ b/src/checkout/src/checkout/shipping/MockShippingService.ts
@@ -22,22 +22,25 @@ import { IShippingService } from './IShippingService';
 
 export class MockShippingService implements IShippingService {
 
+  constructor(private prefix: string) { }
+
   async getShippingRates(request : CheckoutRequest) : Promise<ShippingRates> {
     return Promise.resolve({
       shipmentId: this.makeid(32),
       rates: [{
-        name: "Priority Mail",
+        name: `${this.prefix}Priority Mail`,
         amount: 5,
         token: "priority-mail",
         estimatedDays: 10
       }, {
-        name: "Priority Mail Express",
+        name: `${this.prefix}Priority Mail Express`,
         amount: 15,
         token: "priority-mail-express",
         estimatedDays: 5
       }]
     });
   }
+  
 
   private makeid(length) {
     let result             = '';

--- a/src/checkout/src/config/configuration.ts
+++ b/src/checkout/src/config/configuration.ts
@@ -25,5 +25,8 @@ export default () => ({
     reader: {
       url: process.env.REDIS_READER_URL || '',
     }
+  },
+  shipping: {
+    prefix: process.env.SHIPPING_NAME_PREFIX || ''
   }
 });


### PR DESCRIPTION
Adds the parameter `SHIPPING_NAME_PREFIX` to the checkout service which will prefix all shipping option names with the provided string. This is useful to illustrate backend A/B scenarios without building a separate image.

The parameter is empty by default.