### PR TITLE
fix: Disable firefox/gecko in webdriver manager

### DIFF
--- a/src/e2e/package.json
+++ b/src/e2e/package.json
@@ -5,7 +5,7 @@
   "main": "conf.js",
   "scripts": {
     "test": "protractor conf.js",
-    "postinstall": "./node_modules/protractor/bin/webdriver-manager update --versions.chrome=90.0.4430.212"
+    "postinstall": "./node_modules/protractor/bin/webdriver-manager update --gecko false --versions.chrome=90.0.4430.212"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
There are been repeated GitHub API throttling in CI jobs which seems to be related to the gecko driver. This is being disabled to make the tests more stable.