### PR TITLE
fix: Disable PVC persistence by default in helm charts

### DIFF
--- a/deploy/kubernetes/charts/assets/templates/tests/test-connection.yaml
+++ b/deploy/kubernetes/charts/assets/templates/tests/test-connection.yaml
@@ -11,5 +11,5 @@ spec:
     - name: wget
       image: busybox
       command: ['wget']
-      args: ['{{ include "assets.fullname" . }}:{{ .Values.service.port }}']
+      args: ['{{ include "assets.fullname" . }}:{{ .Values.service.port }}/health.html']
   restartPolicy: Never

--- a/deploy/kubernetes/charts/catalog/values.yaml
+++ b/deploy/kubernetes/charts/catalog/values.yaml
@@ -104,7 +104,7 @@ mysql:
   affinity: {}
 
   persistentVolume:
-    enabled: true
+    enabled: false
     annotations: {}
     labels: {}
     accessModes:

--- a/deploy/kubernetes/charts/orders/values.yaml
+++ b/deploy/kubernetes/charts/orders/values.yaml
@@ -109,7 +109,7 @@ mysql:
   affinity: {}
 
   persistentVolume:
-    enabled: true
+    enabled: false
     annotations: {}
     labels: {}
     accessModes:
@@ -149,7 +149,7 @@ rabbitmq:
   affinity: {}
 
   persistentVolume:
-    enabled: true
+    enabled: false
     annotations: {}
     labels: {}
     accessModes:


### PR DESCRIPTION
PVC persistence should be turned off by default in the helm charts so that it functions on Kubernetes clusters with no CSI driver.