### PR TITLE
fix: Increase UI component memory request in docker compose

### DIFF
--- a/deploy/docker-compose/docker-compose.yml
+++ b/deploy/docker-compose/docker-compose.yml
@@ -31,7 +31,7 @@ services:
     hostname: ui
     image: retail-store-sample-ui:${TAG:-latest}
     restart: always
-    mem_limit: 256m
+    mem_limit: 512m
     cap_drop:
       - ALL
 


### PR DESCRIPTION
Increases the UI component request from 256M to 512M since the former was causing crashes when running the load generator.