### PR TITLE
fix: Remediate Thymeleaf deprecation warnings

### DIFF
--- a/src/ui/src/main/resources/templates/detail.html
+++ b/src/ui/src/main/resources/templates/detail.html
@@ -24,7 +24,7 @@
                         <div class="box">
                             <h1 th:text="${item.name}">White Blouse Armani</h1>
                             <div class="price">$<th:block th:text="${item.price}">124.00</th:block></div>
-                            <div class="mb-3" th:insert="fragments/stars.html :: stars">
+                            <div class="mb-3" th:insert="~{fragments/stars.html :: stars}">
                             </div>
                             <p th:text="${item.description}">White lace top, woven, has a round neck, short sleeves, has knitted lining attached</p>
                             <hr>

--- a/src/ui/src/main/resources/templates/fragments/checkout.html
+++ b/src/ui/src/main/resources/templates/fragments/checkout.html
@@ -36,7 +36,7 @@
                         </ul>
                         <hr/>
                         <div class="mt-4">
-                            <th:block th:include="${template1}"/>
+                            <th:block th:insert="${template1}"/>
                         </div>
                     </div>
                 </article>

--- a/src/ui/src/main/resources/templates/fragments/layout.html
+++ b/src/ui/src/main/resources/templates/fragments/layout.html
@@ -37,7 +37,7 @@
             </div>
         </nav>
         <div>
-          <th:block th:include="${template}"/>
+          <th:block th:insert="${template}"/>
         </div>
         <footer class="text-center text-lg-start bg-primary mt-auto">
           <section class="d-flex justify-content-center justify-content-lg-between p-4 border-bottom">

--- a/src/ui/src/main/resources/templates/fragments/product_card.html
+++ b/src/ui/src/main/resources/templates/fragments/product_card.html
@@ -5,7 +5,7 @@
             <div class="py-2">
                 <div>
                     <a th:href="@{/catalog/{itemId}(itemId=${product.id})}" class="product-link" href="#"><h5 class="fw-bolder" th:text="${product.name}">Fancy Product</h5></a>
-                    <div class="mb-2" th:insert="fragments/stars.html :: stars"/>
+                    <div class="mb-2" th:insert="~{fragments/stars.html :: stars}"/>
                     <div>$<span th:text="${product.price}">143.00</span></div>
                 </div>
             </div>


### PR DESCRIPTION
The UI component is reporting deprecation warnings for Thymeleaf directives:

```
v2023-05-18T18:57:39.993Z  WARN 1 --- [tor-tcp-epoll-3] o.t.s.p.StandardIncludeTagProcessor      : [THYMELEAF][reactor-tcp-epoll-3][fragments/layout] Deprecated attribute {th:include,data-th-include} found in template fragments/layout, line 40, col 21. Please use {th:insert,data-th-insert} instead, this deprecated attribute will be removed in future versions of Thymeleaf.
�2023-05-18T18:57:39.994Z  WARN 1 --- [tor-tcp-epoll-3] actStandardFragmentInsertionTagProcessor : [THYMELEAF][reactor-tcp-epoll-3][detail] Deprecated unwrapped fragment expression "fragments/stars.html :: stars" found in template detail, line 27, col 47. Please use the complete syntax of fragment expressions instead ("~{fragments/stars.html :: stars}"). The old, unwrapped syntax for fragment expressions will be removed in future versions of Thymeleaf.
z2023-05-18T18:57:40.057Z  WARN 1 --- [tor-tcp-epoll-3] o.t.s.p.StandardIncludeTagProcessor      : [THYMELEAF][reactor-tcp-epoll-3][fragments/checkout] Deprecated attribute {th:include,data-th-include} found in template fragments/checkout, line 39, col 39. Please use {th:insert,data-th-insert} instead, this deprecated attribute will be removed in future versions of Thymeleaf.
```

This PR migrates to the recommendation replacements.