### PR TITLE
build: Move images to be based on Amazon Linux 2023

### DIFF
--- a/images/go/Dockerfile
+++ b/images/go/Dockerfile
@@ -1,8 +1,14 @@
 # Build Stage
-FROM amazonlinux:2 as build-env
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023 as build-env
 
-RUN yum install -q -y git golang && \
-    yum clean all
+# We tell DNF not to install Recommends and Suggests packages, which are
+# weak dependencies in DNF terminology, thus keeping our installed set of
+# packages as minimal as possible.
+RUN dnf --setopt=install_weak_deps=False install -q -y \
+    git \
+    golang \
+    && \
+    dnf clean all
 
 ARG MAIN_PATH
 
@@ -12,18 +18,23 @@ WORKDIR /appsrc
 
 COPY . .
 
+ENV GOPROXY=direct
 RUN go build -o main $MAIN_PATH
 
 # Final stage
-FROM amazonlinux:2
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 
 ENV APPUSER=appuser
 ENV APPUID=1000
 ENV APPGID=1000
 
-RUN yum install -q -y \
-    shadow-utils && \
-    yum clean all
+# We tell DNF not to install Recommends and Suggests packages, which are
+# weak dependencies in DNF terminology, thus keeping our installed set of
+# packages as minimal as possible.
+RUN dnf --setopt=install_weak_deps=False install -q -y \
+    shadow-utils \
+    && \
+    dnf clean all
 
 RUN useradd \
     --home "/app" \

--- a/images/java17/Dockerfile
+++ b/images/java17/Dockerfile
@@ -1,5 +1,14 @@
 # Build Stage
-FROM amazoncorretto:17-al2-full as build-env
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023 as build-env
+
+# We tell DNF not to install Recommends and Suggests packages, keeping our
+# installed set of packages as minimal as possible.
+RUN dnf --setopt=install_weak_deps=False install -q -y \
+    maven \
+    java-17-amazon-corretto-headless \
+    which \
+    && \
+    dnf clean all
 
 ARG JAR_PATH
 
@@ -18,13 +27,18 @@ RUN ./mvnw -DskipTests package -q && \
     mv /$JAR_PATH /app.jar
 
 # Package Stage
-FROM amazoncorretto:17-al2-full
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
+
+# We tell DNF not to install Recommends and Suggests packages, which are
+# weak dependencies in DNF terminology, thus keeping our installed set of
+# packages as minimal as possible.
+RUN dnf --setopt=install_weak_deps=False install -q -y \
+    java-17-amazon-corretto-headless \
+    shadow-utils \
+    && \
+    dnf clean all
 
 ARG aws_opentelemetry_agent_version=1.24.0
-
-RUN yum install -q -y \
-    shadow-utils wget && \
-    yum clean all
 
 ENV APPUSER=appuser
 ENV APPUID=1000
@@ -37,8 +51,8 @@ RUN useradd \
     --uid "$APPUID" \
     "$APPUSER"
 
-RUN wget https://github.com/aws-observability/aws-otel-java-instrumentation/releases/download/v${aws_opentelemetry_agent_version}/aws-opentelemetry-agent.jar -O /opt/aws-opentelemetry-agent.jar && \
-    wget https://raw.githubusercontent.com/aws-observability/aws-otel-java-instrumentation/v${aws_opentelemetry_agent_version}/licenses/licenses.md -O aws-opentelemetry-agent-licenses.md
+RUN curl -L https://github.com/aws-observability/aws-otel-java-instrumentation/releases/download/v${aws_opentelemetry_agent_version}/aws-opentelemetry-agent.jar -o /opt/aws-opentelemetry-agent.jar && \
+    curl -L https://raw.githubusercontent.com/aws-observability/aws-otel-java-instrumentation/v${aws_opentelemetry_agent_version}/licenses/licenses.md -o aws-opentelemetry-agent-licenses.md
 ENV JAVA_TOOL_OPTIONS=-javaagent:/opt/aws-opentelemetry-agent.jar
 ENV OTEL_JAVAAGENT_ENABLED=false
 

--- a/images/nodejs/Dockerfile
+++ b/images/nodejs/Dockerfile
@@ -1,7 +1,14 @@
-FROM amazonlinux:2
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 
-RUN yum install -q -y libstdc++.i686 glibc.i686 tar gzip xz shadow-utils && \
-    yum clean all
+# We tell DNF not to install Recommends and Suggests packages, which are
+# weak dependencies in DNF terminology, thus keeping our installed set of
+# packages as minimal as possible.
+RUN dnf --setopt=install_weak_deps=False install -q -y \
+    nodejs \
+    npm \
+    shadow-utils \
+    && \
+    dnf clean all
 
 ENV APPUSER=appuser
 ENV APPUID=1000
@@ -13,17 +20,6 @@ RUN useradd \
     --user-group \
     --uid "$APPUID" \
     "$APPUSER"
-
-ARG TARGETARCH
-ENV NODE_VERSION 16.18.1
-
-RUN DEBARCH="$TARGETARCH"; \
-    if [ "$DEBARCH" = "amd64" ]; then DEBARCH=x64; fi; \
-    echo "Pulling https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${DEBARCH}.tar.xz" && \
-    curl -LSs https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-${DEBARCH}.tar.xz -o node.tar.xz && \
-    tar xf node.tar.xz --directory /tmp && \
-    cp -R /tmp/node-v${NODE_VERSION}-linux-${DEBARCH}/* /usr && \
-    rm -rf node-v${NODE_VERSION}-linux-${DEBARCH} node.tar.xz
 
 WORKDIR /app
 USER appuser

--- a/src/assets/Dockerfile
+++ b/src/assets/Dockerfile
@@ -1,8 +1,11 @@
-FROM amazonlinux:2
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
+
+# We tell DNF not to install Recommends and Suggests packages, which are
+# weak dependencies in DNF terminology, thus keeping our installed set of
+# packages as minimal as possible.
+RUN dnf --setopt=install_weak_deps=False -y install nginx
 
 EXPOSE 8080
-
-RUN amazon-linux-extras install -y nginx1
 
 COPY default.conf /etc/nginx/nginx.conf
 COPY mime.types /etc/nginx/mime.types

--- a/src/load-generator/Dockerfile
+++ b/src/load-generator/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazonlinux:2
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 
 COPY helpers.js /artillery/helpers.js
 COPY scenario.yml /artillery/scenario.yml


### PR DESCRIPTION
We get a few advantages with moving to Amazon Linux 2023, the most notable being that we get to use more packages provided by the OS rather than downloading some. For example, we can use the node and npm binaries from the RPM packages in AL2023.

We also take the opportunity to move to pulling base images from ECR rather than DockerHub.

Using curl rather than wget also means we don't need to add wget to the list of packages we're installing in the container, thus keeping things nice and minimal.