### PR TITLE
fix: Prevent orders metrics NaN with proper reference

### DIFF
--- a/src/orders/src/test/java/com/amazon/sample/orders/metrics/OrdersMetricsTest.java
+++ b/src/orders/src/test/java/com/amazon/sample/orders/metrics/OrdersMetricsTest.java
@@ -100,7 +100,9 @@ public class OrdersMetricsTest {
         var watchGauge = meterRegistry.find("watch.orderTotal").gauge();
         then(watchGauge).isNotNull();
         then(watchGauge.value()).isEqualTo(600.0);
+
+        ordersMetrics.onOrderCreated(event);
+
+        then(watchGauge.value()).isEqualTo(1200.0);
     }
-
-
 }


### PR DESCRIPTION
Orders unit test were regularly failing with:

```
Error:    OrdersMetricsTest.testCreateCounterAndIncrement:102 
expected: 600.0
 but was: NaN
```

This shows the reference to the metric value has not being maintained properly.

Resolved this by changing how gauge is created and integer value is referenced.