### PR TITLE
style: Fix spelling error on Oops

### DIFF
--- a/src/ui/src/main/resources/templates/fragments/error.html
+++ b/src/ui/src/main/resources/templates/fragments/error.html
@@ -11,7 +11,7 @@
 <div class="d-flex align-items-center justify-content-center vh-100">
     <div class="text-center">
         <h1 class="display-1 fw-bold" th:text="${code}">404</h1>
-        <p class="fs-3"> <span class="text-danger">Opps!</span> Sorry.</p>
+        <p class="fs-3"> <span class="text-danger">Oops!</span> Sorry.</p>
         <p class="lead">
             An error has occurred, you better go back.
         </p>


### PR DESCRIPTION
Corrected error message from "Opps! Sorry." to "Oops! Sorry."