### PR TITLE
chore: Terraform AWS provider v5 updates

### DIFF
--- a/deploy/terraform/lib/dependencies/elasticache.tf
+++ b/deploy/terraform/lib/dependencies/elasticache.tf
@@ -1,6 +1,6 @@
 module "checkout-elasticache-redis" {
   source  = "cloudposse/elasticache-redis/aws"
-  version = "0.49.0"
+  version = "0.52.0"
 
   name                       = "${var.environment_name}-checkout"
   vpc_id                     = var.vpc_id

--- a/deploy/terraform/lib/eks/eks.tf
+++ b/deploy/terraform/lib/eks/eks.tf
@@ -126,7 +126,7 @@ resource "aws_security_group_rule" "istio_citadel" {
 }
 
 module "eks_cluster_kubernetes_addons" {
-  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.26.0"
+  source = "github.com/aws-ia/terraform-aws-eks-blueprints//modules/kubernetes-addons?ref=v4.32.1"
 
   providers = {
     kubernetes = kubernetes.addons

--- a/deploy/terraform/lib/vpc/vpc.tf
+++ b/deploy/terraform/lib/vpc/vpc.tf
@@ -10,7 +10,7 @@ data "aws_availability_zones" "available" {
 
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "3.18.1"
+  version = "5.1.1"
 
   name = var.environment_name
   cidr = var.vpc_cidr


### PR DESCRIPTION
Updates several Terraform modules for compatibility with the AWS v5 provider. Also bumps the version of EKS blueprints for Terraform module version.