### PR TITLE
chore: Migrated carts service to AWS SDK for Java v2

### DIFF
--- a/src/cart/pom.xml
+++ b/src/cart/pom.xml
@@ -30,7 +30,7 @@
 			<dependency>
 				<groupId>software.amazon.awssdk</groupId>
 				<artifactId>bom</artifactId>
-				<version>2.20.125</version>
+				<version>2.21.45</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/src/cart/pom.xml
+++ b/src/cart/pom.xml
@@ -25,6 +25,18 @@
     <mapstruct.version>1.5.5.Final</mapstruct.version>
   </properties>
 
+  <dependencyManagement>
+		<dependencies>
+			<dependency>
+				<groupId>software.amazon.awssdk</groupId>
+				<artifactId>bom</artifactId>
+				<version>2.20.125</version>
+				<type>pom</type>
+				<scope>import</scope>
+			</dependency>
+		</dependencies>
+	</dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -69,15 +81,17 @@
       <artifactId>spring-boot-starter-data-mongodb</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-dynamodb</artifactId>
-      <version>1.12.603</version>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>dynamodb</artifactId>
+		</dependency>
+    <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>dynamodb-enhanced</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-sts</artifactId>
-      <version>1.12.578</version>
-    </dependency>
+			<groupId>software.amazon.awssdk</groupId>
+			<artifactId>sts</artifactId>
+		</dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>

--- a/src/cart/src/main/java/com/amazon/sample/carts/configuration/DynamoDBProperties.java
+++ b/src/cart/src/main/java/com/amazon/sample/carts/configuration/DynamoDBProperties.java
@@ -19,7 +19,6 @@
 package com.amazon.sample.carts.configuration;
 
 import lombok.Data;
-import lombok.Getter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 

--- a/src/cart/src/main/java/com/amazon/sample/carts/repositories/dynamo/entities/DynamoItemEntity.java
+++ b/src/cart/src/main/java/com/amazon/sample/carts/repositories/dynamo/entities/DynamoItemEntity.java
@@ -18,13 +18,13 @@
 
 package com.amazon.sample.carts.repositories.dynamo.entities;
 
-import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBAttribute;
-import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
-import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBIndexHashKey;
-import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey;
+import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbSecondaryPartitionKey;
+
 import com.amazon.sample.carts.repositories.ItemEntity;
 
-@DynamoDBTable(tableName="Items")
+@DynamoDbBean()
 public class DynamoItemEntity implements ItemEntity {
     private String id;
 
@@ -48,28 +48,24 @@ public class DynamoItemEntity implements ItemEntity {
 
     }
 
-    @DynamoDBHashKey
+    @DynamoDbPartitionKey
     public String getId() {
         return id;
     }
 
-    @DynamoDBAttribute
-    @DynamoDBIndexHashKey(globalSecondaryIndexName = "idx_global_customerId")
+    @DynamoDbSecondaryPartitionKey(indexNames = {"idx_global_customerId"})
     public String getCustomerId() {
         return customerId;
     }
 
-    @DynamoDBAttribute
     public String getItemId() {
         return itemId;
     }
 
-    @DynamoDBAttribute
     public int getQuantity() {
         return quantity;
     }
 
-    @DynamoDBAttribute
     public int getUnitPrice() {
         return unitPrice;
     }

--- a/src/cart/src/main/java/com/amazon/sample/carts/services/DynamoDBCartService.java
+++ b/src/cart/src/main/java/com/amazon/sample/carts/services/DynamoDBCartService.java
@@ -18,66 +18,70 @@
 
 package com.amazon.sample.carts.services;
 
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
-import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
-import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBQueryExpression;
-import com.amazonaws.services.dynamodbv2.datamodeling.PaginatedQueryList;
-import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
-import com.amazonaws.services.dynamodbv2.model.DeleteTableRequest;
-import com.amazonaws.services.dynamodbv2.model.Projection;
-import com.amazonaws.services.dynamodbv2.model.ProvisionedThroughput;
 import com.amazon.sample.carts.repositories.CartEntity;
 import com.amazon.sample.carts.repositories.ItemEntity;
 import com.amazon.sample.carts.repositories.dynamo.entities.DynamoItemEntity;
 import lombok.extern.slf4j.Slf4j;
-
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbIndex;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbTable;
+import software.amazon.awssdk.enhanced.dynamodb.Key;
+import software.amazon.awssdk.enhanced.dynamodb.TableSchema;
+import software.amazon.awssdk.enhanced.dynamodb.model.Page;
+import software.amazon.awssdk.enhanced.dynamodb.model.QueryConditional;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.DeleteTableRequest;
+import software.amazon.awssdk.services.dynamodb.model.ProjectionType;
+import software.amazon.awssdk.services.dynamodb.model.ResourceNotFoundException;
 import jakarta.annotation.PostConstruct;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 
 @Slf4j
 public class DynamoDBCartService implements CartService {
 
-    private final DynamoDBMapper mapper;
-    private final AmazonDynamoDB dynamoDB;
+    private final DynamoDbClient dynamoDBClient;
     private final boolean createTable;
+    private final DynamoDbTable<DynamoItemEntity> table;
 
-    public DynamoDBCartService(DynamoDBMapper mapper, AmazonDynamoDB dynamoDB, boolean createTable) {
-        this.mapper = mapper;
-        this.dynamoDB = dynamoDB;
+    static final TableSchema<DynamoItemEntity> CART_TABLE_SCHEMA = TableSchema.fromClass(DynamoItemEntity.class);
+
+    public DynamoDBCartService(DynamoDbClient dynamoDBClient,DynamoDbEnhancedClient dynamoDbEnhancedClient, boolean createTable) {
+        this.dynamoDBClient = dynamoDBClient;
         this.createTable = createTable;
+
+        this.table = dynamoDbEnhancedClient.table("Items", CART_TABLE_SCHEMA);
     }
 
     @PostConstruct
     public void init() {
         if(createTable) {
-            DeleteTableRequest deleteTableRequest = mapper.generateDeleteTableRequest(DynamoItemEntity.class);
-
             try {
-                dynamoDB.describeTable(deleteTableRequest.getTableName());
-
-                log.warn("Dynamo table found, deleting to recreate....");
-                dynamoDB.deleteTable(deleteTableRequest);
+                dynamoDBClient.deleteTable(
+                DeleteTableRequest.builder().tableName("Items").build()
+            );
             }
-            catch (com.amazonaws.services.dynamodbv2.model.ResourceNotFoundException rnfe) {
-                log.warn("Dynamo "+deleteTableRequest.getTableName()+" table not found");
+            catch (ResourceNotFoundException rnfe) {
+                log.warn("Dynamo table not found");
             }
 
-            ProvisionedThroughput pt = new ProvisionedThroughput(1L, 1L);
+            this.table.createTable(builder -> builder
+                .globalSecondaryIndices(builder3 -> builder3
+                        .indexName("idx_global_customerId")
+                        
+                        .projection(builder2 -> builder2
+                                .projectionType(ProjectionType.ALL))
+                        .provisionedThroughput(builder4 -> builder4
+                                .writeCapacityUnits(1L)
+                                .readCapacityUnits(1L)))
+                .provisionedThroughput(b -> b
+                    .readCapacityUnits(1L)
+                    .writeCapacityUnits(1L)
+                    .build()));
 
-            CreateTableRequest tableRequest = mapper
-                    .generateCreateTableRequest(DynamoItemEntity.class);
-            tableRequest.setProvisionedThroughput(pt);
-            tableRequest.getGlobalSecondaryIndexes().get(0).setProvisionedThroughput(pt);
-            tableRequest.getGlobalSecondaryIndexes().get(0).setProjection(new Projection().withProjectionType("ALL"));
-            dynamoDB.createTable(tableRequest);
-
-            try {
-                Thread.sleep(1000);
-            } catch (InterruptedException e) {
-                e.printStackTrace();
-            }
+            this.dynamoDBClient.waiter().waitUntilTableExists(b -> b.tableName("Items"));
         }
     }
 
@@ -102,7 +106,9 @@ public class DynamoDBCartService implements CartService {
     public void delete(String customerId) {
         List<DynamoItemEntity> items = items(customerId);
 
-        mapper.batchDelete(items);
+        items.forEach(item -> {
+            this.table.deleteItem(item);
+        });
     }
 
     @Override
@@ -114,7 +120,7 @@ public class DynamoDBCartService implements CartService {
     public ItemEntity add(String customerId, String itemId, int quantity, int unitPrice) {
         String hashKey = hashKey(customerId, itemId);
 
-        DynamoItemEntity item = this.mapper.load(DynamoItemEntity.class, hashKey);
+        DynamoItemEntity item = this.table.getItem(Key.builder().partitionValue(hashKey(customerId, itemId)).build());
 
         if(item != null) {
             item.setQuantity(item.getQuantity() + quantity);
@@ -123,34 +129,34 @@ public class DynamoDBCartService implements CartService {
             item = new DynamoItemEntity(hashKey, customerId, itemId, 1, unitPrice);
         }
 
-        this.mapper.save(item);
+        this.table.putItem(item);
 
         return item;
     }
 
     @Override
     public List<DynamoItemEntity> items(String customerId) {
-        final DynamoItemEntity gsiKeyObj = new DynamoItemEntity();
-        gsiKeyObj.setCustomerId(customerId);
-        final DynamoDBQueryExpression<DynamoItemEntity> queryExpression =
-                new DynamoDBQueryExpression<>();
-        queryExpression.setHashKeyValues(gsiKeyObj);
-        queryExpression.setIndexName("idx_global_customerId");
-        queryExpression.setConsistentRead(false);   // cannot use consistent read on GSI
-        final PaginatedQueryList<DynamoItemEntity> results =
-                mapper.query(DynamoItemEntity.class, queryExpression);
+        DynamoDbIndex<DynamoItemEntity> index = this.table.index("idx_global_customerId");
+        QueryConditional q = QueryConditional.keyEqualTo(Key.builder().partitionValue(customerId).build());
+        Iterator<Page<DynamoItemEntity>> result = index.query(q).iterator();
+        List<DynamoItemEntity> users = new ArrayList<>();
 
-        return new ArrayList<>(results);
+        while (result.hasNext()) {
+            Page<DynamoItemEntity> userPage = result.next();
+            users.addAll(userPage.items());
+        }
+
+        return users;
     }
 
     @Override
     public Optional<DynamoItemEntity> item(String customerId, String itemId) {
-        return Optional.of(mapper.load(DynamoItemEntity.class, hashKey(customerId, itemId)));
+        return Optional.of(this.table.getItem(Key.builder().partitionValue(hashKey(customerId, itemId)).build()));
     }
 
     @Override
     public void deleteItem(String customerId, String itemId) {
-        item(customerId, itemId).ifPresentOrElse(this.mapper::delete,
+        item(customerId, itemId).ifPresentOrElse(this.table::deleteItem,
         ()
             -> log.warn("Item missing for delete {} -- {}", customerId, itemId));
     }
@@ -162,7 +168,7 @@ public class DynamoDBCartService implements CartService {
                 item.setQuantity(quantity);
                 item.setUnitPrice(unitPrice);
 
-                this.mapper.save(item);
+                this.table.updateItem(item);
 
                 return item;
             }

--- a/src/cart/src/test/java/com/amazon/sample/carts/services/DynamoDBCartServiceTests.java
+++ b/src/cart/src/test/java/com/amazon/sample/carts/services/DynamoDBCartServiceTests.java
@@ -18,8 +18,9 @@
 
 package com.amazon.sample.carts.services;
 
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
-import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper;
+import software.amazon.awssdk.enhanced.dynamodb.DynamoDbEnhancedClient;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+
 import com.amazon.sample.carts.configuration.DynamoDBConfiguration;
 import com.amazon.sample.carts.configuration.DynamoDBProperties;
 import org.junit.jupiter.api.Tag;
@@ -54,7 +55,7 @@ public class DynamoDBCartServiceTests extends AbstractServiceTests {
     private DynamoDBCartService service;
 
     @Autowired
-    private AmazonDynamoDB dynamodb;
+    private DynamoDbClient dynamoDbClient;
 
     @Container
     public static GenericContainer dynamodbContainer =
@@ -72,10 +73,10 @@ public class DynamoDBCartServiceTests extends AbstractServiceTests {
     static class TestConfiguration {
 
         @Autowired
-        private AmazonDynamoDB amazonDynamoDB;
+        private DynamoDbClient dynamoDbClient;
 
         @Autowired
-        private DynamoDBMapper mapper;
+        private DynamoDbEnhancedClient dynamoDbEnhancedClient;
     }
 
     public static class Initializer implements


### PR DESCRIPTION
In order for the new EKS pod identity feature to work the carts service needed to be migrated to the AWS SDK for Java v2.