### PR TITLE
chore: Migrate RabbitMQ broker to base TF provider

### DIFF
--- a/deploy/terraform/lib/dependencies/mq.tf
+++ b/deploy/terraform/lib/dependencies/mq.tf
@@ -1,29 +1,54 @@
 locals {
-  mq_default_user = "default_mq_user"
-}
-
-module "orders_mq_broker" {
-  source  = "cloudposse/mq-broker/aws"
-  version = "3.0.0"
-
-  name                       = "${var.environment_name}_orders_mq-broker"
-  vpc_id                     = var.vpc_id
-  subnet_ids                 = [var.subnet_ids[0]]
-  mq_admin_user              = [local.mq_default_user]
-  mq_admin_password          = [random_password.mq_password.result]
-  deployment_mode            = "SINGLE_INSTANCE"
-  engine_type                = "RabbitMQ"
-  engine_version             = "3.10.10"
-  audit_log_enabled          = false
-  encryption_enabled         = false
-
+  mq_default_user            = "default_mq_user"
   allowed_security_group_ids = concat(var.allowed_security_group_ids, [var.orders_security_group_id])
-
-  tags             = var.tags
 }
 
 resource "random_password" "mq_password" {
   length           = 16
   special          = true
   override_special = "!#$%&*()-_+{}<>?"
+}
+
+resource "aws_mq_broker" "mq" {
+  broker_name = "${var.environment_name}-orders-broker"
+
+  engine_type         = "RabbitMQ"
+  engine_version      = "3.10.10"
+  host_instance_type  = "mq.t3.micro"
+  deployment_mode     = "SINGLE_INSTANCE"
+  subnet_ids          = [var.subnet_ids[0]]
+  security_groups     = [aws_security_group.mq.id]
+  apply_immediately   = true
+  publicly_accessible = false
+
+  user {
+    username = local.mq_default_user
+    password = random_password.mq_password.result
+  }
+
+  tags = var.tags
+}
+
+resource "aws_security_group" "mq" {
+  name        = "${var.environment_name}-orders-broker"
+  vpc_id      = var.vpc_id
+  description = "Secure traffic to Rabbit MQ"
+
+  tags = merge(var.tags, { Name = "${var.environment_name}-orders-broker" })
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_security_group_rule" "mq" {
+  for_each = toset(local.allowed_security_group_ids)
+
+  type              = "ingress"
+  from_port         = 5671
+  to_port           = 5671
+  protocol          = "tcp"
+  security_group_id = aws_security_group.mq.id
+
+  source_security_group_id = each.key
 }

--- a/deploy/terraform/lib/dependencies/outputs.tf
+++ b/deploy/terraform/lib/dependencies/outputs.tf
@@ -88,23 +88,23 @@ output "carts_dynamodb_policy_arn" {
 }
 
 output "mq_broker_id" {
-  value       = module.orders_mq_broker.broker_id
+  value       = aws_mq_broker.mq.id
   description = "AmazonMQ broker ID"
 }
 
 output "mq_broker_arn" {
-  value       = module.orders_mq_broker.broker_arn
+  value       = aws_mq_broker.mq.arn
   description = "AmazonMQ broker ARN"
 }
 
 output "mq_broker_endpoint" {
-  value       = module.orders_mq_broker.primary_ssl_endpoint
+  value       = aws_mq_broker.mq.instances[0].endpoints[0]
   description = "AmazonMQ broker endpoint"
 }
 
 output "mq_password" {
-  value     = random_password.mq_password.result
-  sensitive = true
+  value       = random_password.mq_password.result
+  sensitive   = true
   description = "AmazonMQ Admin password."
 }
 
@@ -114,21 +114,21 @@ output "mq_user" {
 }
 
 output "checkout_elasticache_arn" {
-    value = module.checkout-elasticache-redis.arn
-    description = "Checkout Redis ElastiCache ARN."
+  value       = module.checkout-elasticache-redis.arn
+  description = "Checkout Redis ElastiCache ARN."
 }
 
 output "checkout_elasticache_primary_endpoint" {
-    value = module.checkout-elasticache-redis.endpoint
-    description = "Checkout Redis hostname"
+  value       = module.checkout-elasticache-redis.endpoint
+  description = "Checkout Redis hostname"
 }
 
 output "checkout_elasticache_reader_endpoint" {
-    value = module.checkout-elasticache-redis.reader_endpoint_address
-    description = "Checkout Redis reader hostname"
+  value       = module.checkout-elasticache-redis.reader_endpoint_address
+  description = "Checkout Redis reader hostname"
 }
 
 output "checkout_elasticache_port" {
-    value = module.checkout-elasticache-redis.port
-    description = "Checkout Redis port"
+  value       = module.checkout-elasticache-redis.port
+  description = "Checkout Redis port"
 }


### PR DESCRIPTION
Migrate the RabbitMQ TF configuration to the base AWS provider to make the configuration less opaque and easier to maintain.