### PR TITLE
feat: Added configurable container image variables to Terraform

### DIFF
--- a/deploy/terraform/apprunner/main.tf
+++ b/deploy/terraform/apprunner/main.tf
@@ -40,11 +40,13 @@ module "dependencies" {
 module "retail_app_apprunner" {
   source = "../lib/apprunner"
 
-  environment_name = var.environment_name
-  vpc_id           = module.vpc.inner.vpc_id
-  vpc_cidr         = module.vpc.inner.vpc_cidr_block
-  subnet_ids       = module.vpc.inner.private_subnets
-  tags             = module.tags.result
+  environment_name          = var.environment_name
+  vpc_id                    = module.vpc.inner.vpc_id
+  vpc_cidr                  = module.vpc.inner.vpc_cidr_block
+  subnet_ids                = module.vpc.inner.private_subnets
+  tags                      = module.tags.result
+  container_image_overrides = var.container_image_overrides
+  image_repository_type     = var.image_repository_type
 
   catalog_db_endpoint = module.dependencies.catalog_db_endpoint
   catalog_db_port     = module.dependencies.catalog_db_port

--- a/deploy/terraform/apprunner/variables.tf
+++ b/deploy/terraform/apprunner/variables.tf
@@ -2,3 +2,14 @@ variable "environment_name" {
   type    = string
   default = "retail-store-ar"
 }
+
+variable "container_image_overrides" {
+  type        = any
+  default     = {}
+  description = "Container image override object"
+}
+
+variable "image_repository_type" {
+  description = "The type of image repository where the images will be pulled from"
+  default     = "ECR_PUBLIC"
+}

--- a/deploy/terraform/eks/default/kubernetes.tf
+++ b/deploy/terraform/eks/default/kubernetes.tf
@@ -30,6 +30,12 @@ locals {
   })
 }
 
+module "container_images" {
+  source = "../../lib/images"
+
+  container_image_overrides = var.container_image_overrides
+}
+
 resource "null_resource" "cluster_blocker" {
   triggers = {
     "blocker" = module.retail_app_eks.cluster_blocker_id
@@ -70,6 +76,8 @@ resource "helm_release" "assets" {
   namespace = kubernetes_namespace_v1.assets.metadata[0].name
   values = [
     templatefile("${path.module}/values/assets.yaml", {
+      image_repository      = module.container_images.result.assets.repository
+      image_tag             = module.container_images.result.assets.tag
       opentelemetry_enabled = var.opentelemetry_enabled
     })
   ]
@@ -95,6 +103,8 @@ resource "helm_release" "catalog" {
 
   values = [
     templatefile("${path.module}/values/catalog.yaml", {
+      image_repository      = module.container_images.result.catalog.repository
+      image_tag             = module.container_images.result.catalog.tag
       opentelemetry_enabled = var.opentelemetry_enabled
       database_endpoint     = "${module.dependencies.catalog_db_endpoint}:${module.dependencies.catalog_db_port}"
       database_username     = module.dependencies.catalog_db_master_username
@@ -124,6 +134,8 @@ resource "helm_release" "carts" {
 
   values = [
     templatefile("${path.module}/values/carts.yaml", {
+      image_repository      = module.container_images.result.cart.repository
+      image_tag             = module.container_images.result.cart.tag
       opentelemetry_enabled = var.opentelemetry_enabled
       role_arn              = module.iam_assumable_role_carts.iam_role_arn
       table_name            = module.dependencies.carts_dynamodb_table_name
@@ -151,6 +163,8 @@ resource "helm_release" "checkout" {
 
   values = [
     templatefile("${path.module}/values/checkout.yaml", {
+      image_repository      = module.container_images.result.checkout.repository
+      image_tag             = module.container_images.result.checkout.tag
       opentelemetry_enabled = var.opentelemetry_enabled
       redis_address         = module.dependencies.checkout_elasticache_primary_endpoint
       redis_port            = module.dependencies.checkout_elasticache_port
@@ -179,6 +193,8 @@ resource "helm_release" "orders" {
 
   values = [
     templatefile("${path.module}/values/orders.yaml", {
+      image_repository       = module.container_images.result.orders.repository
+      image_tag              = module.container_images.result.orders.tag
       opentelemetry_enabled  = var.opentelemetry_enabled
       database_endpoint_host = module.dependencies.orders_db_endpoint
       database_endpoint_port = module.dependencies.orders_db_port
@@ -213,6 +229,8 @@ resource "helm_release" "ui" {
 
   values = [
     templatefile("${path.module}/values/ui.yaml", {
+      image_repository      = module.container_images.result.ui.repository
+      image_tag             = module.container_images.result.ui.tag
       opentelemetry_enabled = var.opentelemetry_enabled
       istio_enabled         = var.istio_enabled
     })

--- a/deploy/terraform/eks/default/values/assets.yaml
+++ b/deploy/terraform/eks/default/values/assets.yaml
@@ -1,3 +1,7 @@
+image:
+  repository: ${image_repository}
+  tag: ${image_tag}
+
 %{ if opentelemetry_enabled }
 opentelemetry:
   enabled: true

--- a/deploy/terraform/eks/default/values/carts.yaml
+++ b/deploy/terraform/eks/default/values/carts.yaml
@@ -1,3 +1,7 @@
+image:
+  repository: ${image_repository}
+  tag: ${image_tag}
+
 serviceAccount:
   annotations:
     eks.amazonaws.com/role-arn: ${role_arn}

--- a/deploy/terraform/eks/default/values/catalog.yaml
+++ b/deploy/terraform/eks/default/values/catalog.yaml
@@ -1,3 +1,7 @@
+image:
+  repository: ${image_repository}
+  tag: ${image_tag}
+
 mysql:
   create: false
 

--- a/deploy/terraform/eks/default/values/checkout.yaml
+++ b/deploy/terraform/eks/default/values/checkout.yaml
@@ -1,3 +1,7 @@
+image:
+  repository: ${image_repository}
+  tag: ${image_tag}
+
 redis:
   create: false
 

--- a/deploy/terraform/eks/default/values/orders.yaml
+++ b/deploy/terraform/eks/default/values/orders.yaml
@@ -1,3 +1,7 @@
+image:
+  repository: ${image_repository}
+  tag: ${image_tag}
+
 postgresql:
   create: false
 

--- a/deploy/terraform/eks/default/values/ui.yaml
+++ b/deploy/terraform/eks/default/values/ui.yaml
@@ -1,3 +1,7 @@
+image:
+  repository: ${image_repository}
+  tag: ${image_tag}
+
 endpoints:
   catalog: http://catalog.catalog.svc:80
   carts: http://carts.carts.svc:80

--- a/deploy/terraform/eks/default/variables.tf
+++ b/deploy/terraform/eks/default/variables.tf
@@ -5,12 +5,18 @@ variable "environment_name" {
 
 variable "istio_enabled" {
   description = "Boolean value that enables istio."
-  type        = bool 
+  type        = bool
   default     = false
 }
 
 variable "opentelemetry_enabled" {
   description = "Boolean value that enables OpenTelemetry."
-  type        = bool 
+  type        = bool
   default     = false
+}
+
+variable "container_image_overrides" {
+  type        = any
+  default     = {}
+  description = "Container image override object"
 }

--- a/deploy/terraform/eks/minimal/variables.tf
+++ b/deploy/terraform/eks/minimal/variables.tf
@@ -5,6 +5,6 @@ variable "environment_name" {
 
 variable "istio_enabled" {
   description = "Boolean value that enables istio."
-  type        = bool 
+  type        = bool
   default     = false
 }

--- a/deploy/terraform/lib/apprunner/assets.tf
+++ b/deploy/terraform/lib/apprunner/assets.tf
@@ -9,8 +9,11 @@ module "app_runner_assets" {
       image_configuration = {
         port = 8080
       }
-      image_identifier      = module.container_images.result.assets
-      image_repository_type = "ECR_PUBLIC"
+      image_identifier      = module.container_images.result.assets.url
+      image_repository_type = var.image_repository_type
+    }
+    authentication_configuration = {
+      access_role_arn = aws_iam_role.ecr_access.arn
     }
   }
 

--- a/deploy/terraform/lib/apprunner/carts.tf
+++ b/deploy/terraform/lib/apprunner/carts.tf
@@ -11,9 +11,15 @@ module "app_runner_carts" {
         runtime_environment_variables = {
           CARTS_DYNAMODB_TABLENAME = var.carts_dynamodb_table_name
         }
+        runtime_environment_variables = {
+          SPRING_PROFILES_ACTIVE = "dynamodb"
+        }
       }
-      image_identifier      = module.container_images.result.cart
-      image_repository_type = "ECR_PUBLIC"
+      image_identifier      = module.container_images.result.cart.url
+      image_repository_type = var.image_repository_type
+    }
+    authentication_configuration = {
+      access_role_arn = aws_iam_role.ecr_access.arn
     }
   }
 

--- a/deploy/terraform/lib/apprunner/checkout.tf
+++ b/deploy/terraform/lib/apprunner/checkout.tf
@@ -13,8 +13,11 @@ module "app_runner_checkout" {
           ENDPOINTS_ORDERS = "https://${aws_apprunner_vpc_ingress_connection.orders.domain_name}"
         }
       }
-      image_identifier      = module.container_images.result.checkout
-      image_repository_type = "ECR_PUBLIC"
+      image_identifier      = module.container_images.result.checkout.url
+      image_repository_type = var.image_repository_type
+    }
+    authentication_configuration = {
+      access_role_arn = aws_iam_role.ecr_access.arn
     }
   }
 

--- a/deploy/terraform/lib/apprunner/common.tf
+++ b/deploy/terraform/lib/apprunner/common.tf
@@ -4,8 +4,8 @@ resource "aws_kms_key" "cmk" {
 }
 
 resource "random_string" "random_mq_secret" {
-  length           = 4
-  special          = false
+  length  = 4
+  special = false
 }
 
 resource "aws_secretsmanager_secret" "mq" {
@@ -22,4 +22,33 @@ resource "aws_secretsmanager_secret_version" "mq" {
       host     = var.mq_endpoint
     }
   )
+}
+
+resource "aws_iam_role" "ecr_access" {
+  name = "${var.environment_name}-ecr-access"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Sid    = ""
+        Principal = {
+          Service = "build.apprunner.amazonaws.com"
+        }
+      },
+    ]
+  })
+
+  tags = var.tags
+}
+
+data "aws_iam_policy" "ecr_access" {
+  arn = "arn:aws:iam::aws:policy/service-role/AWSAppRunnerServicePolicyForECRAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "ecr_access" {
+  role       = aws_iam_role.ecr_access.name
+  policy_arn = data.aws_iam_policy.ecr_access.arn
 }

--- a/deploy/terraform/lib/apprunner/ui.tf
+++ b/deploy/terraform/lib/apprunner/ui.tf
@@ -16,8 +16,11 @@ module "app_runner_ui" {
           ENDPOINTS_ASSETS   = "https://${module.app_runner_assets.vpc_ingress_connection_domain_name}"
         }
       }
-      image_identifier      = module.container_images.result.ui
-      image_repository_type = "ECR_PUBLIC"
+      image_identifier      = module.container_images.result.ui.url
+      image_repository_type = var.image_repository_type
+    }
+    authentication_configuration = {
+      access_role_arn = aws_iam_role.ecr_access.arn
     }
   }
 

--- a/deploy/terraform/lib/apprunner/variables.tf
+++ b/deploy/terraform/lib/apprunner/variables.tf
@@ -22,6 +22,11 @@ variable "subnet_ids" {
   type        = list(string)
 }
 
+variable "image_repository_type" {
+  description = "The type of image repository where the images will be pulled from"
+  default     = "ECR_PUBLIC"
+}
+
 variable "container_image_overrides" {
   type        = any
   default     = {}

--- a/deploy/terraform/lib/eks/eks.tf
+++ b/deploy/terraform/lib/eks/eks.tf
@@ -137,10 +137,10 @@ module "eks_cluster_kubernetes_addons" {
     module.eks_cluster
   ]
 
-  eks_cluster_id               = module.eks_cluster.cluster_name
-  eks_cluster_endpoint         = module.eks_cluster.cluster_endpoint
-  eks_oidc_provider            = module.eks_cluster.oidc_provider
-  eks_cluster_version          = module.eks_cluster.cluster_version
+  eks_cluster_id       = module.eks_cluster.cluster_name
+  eks_cluster_endpoint = module.eks_cluster.cluster_endpoint
+  eks_oidc_provider    = module.eks_cluster.oidc_provider
+  eks_cluster_version  = module.eks_cluster.cluster_version
 
   enable_tetrate_istio = var.istio_enabled
 
@@ -151,11 +151,11 @@ module "eks_cluster_kubernetes_addons" {
     create_namespace = true
   }
 
-  enable_amazon_eks_adot                   =true
+  enable_amazon_eks_adot = true
   amazon_eks_adot_config = {
     kubernetes_version = var.cluster_version
   }
-  
+
   tags = var.tags
 }
 

--- a/deploy/terraform/lib/images/main.tf
+++ b/deploy/terraform/lib/images/main.tf
@@ -1,21 +1,22 @@
 locals {
-  default_tag = try(var.container_image_overrides.default_tag, local.published_tag)
+  default_repository = try(var.container_image_overrides.default_repository, local.published_repository)
+  default_tag        = try(var.container_image_overrides.default_tag, local.published_tag)
 
-  assets_default_image = "${local.published_repository}/retail-store-sample-assets:${local.default_tag}"
+  assets_default_image = "${local.default_repository}/retail-store-sample-assets:${local.default_tag}"
   assets_image         = try(var.container_image_overrides.assets, local.assets_default_image)
 
-  catalog_default_image = "${local.published_repository}/retail-store-sample-catalog:${local.default_tag}"
+  catalog_default_image = "${local.default_repository}/retail-store-sample-catalog:${local.default_tag}"
   catalog_image         = try(var.container_image_overrides.catalog, local.catalog_default_image)
 
-  cart_default_image = "${local.published_repository}/retail-store-sample-cart:${local.default_tag}"
+  cart_default_image = "${local.default_repository}/retail-store-sample-cart:${local.default_tag}"
   cart_image         = try(var.container_image_overrides.cart, local.cart_default_image)
 
-  checkout_default_image = "${local.published_repository}/retail-store-sample-checkout:${local.default_tag}"
+  checkout_default_image = "${local.default_repository}/retail-store-sample-checkout:${local.default_tag}"
   checkout_image         = try(var.container_image_overrides.checkout, local.checkout_default_image)
 
-  orders_default_image = "${local.published_repository}/retail-store-sample-orders:${local.default_tag}"
+  orders_default_image = "${local.default_repository}/retail-store-sample-orders:${local.default_tag}"
   orders_image         = try(var.container_image_overrides.orders, local.orders_default_image)
 
-  ui_default_image = "${local.published_repository}/retail-store-sample-ui:${local.default_tag}"
+  ui_default_image = "${local.default_repository}/retail-store-sample-ui:${local.default_tag}"
   ui_image         = try(var.container_image_overrides.ui, local.ui_default_image)
 }

--- a/deploy/terraform/lib/images/outputs.tf
+++ b/deploy/terraform/lib/images/outputs.tf
@@ -1,10 +1,22 @@
 output "result" {
   value = {
-    assets   = local.assets_image
-    catalog  = local.catalog_image
-    cart     = local.cart_image
-    checkout = local.checkout_image
-    orders   = local.orders_image
-    ui       = local.ui_image
+    assets = merge({
+      url = local.assets_image
+    }, zipmap(["repository", "tag"], split(":", local.assets_image)))
+    catalog = merge({
+      url = local.catalog_image
+    }, zipmap(["repository", "tag"], split(":", local.catalog_image)))
+    cart = merge({
+      url = local.cart_image
+    }, zipmap(["repository", "tag"], split(":", local.cart_image)))
+    checkout = merge({
+      url = local.checkout_image
+    }, zipmap(["repository", "tag"], split(":", local.checkout_image)))
+    orders = merge({
+      url = local.orders_image
+    }, zipmap(["repository", "tag"], split(":", local.orders_image)))
+    ui = merge({
+      url = local.ui_image
+    }, zipmap(["repository", "tag"], split(":", local.ui_image)))
   }
 }


### PR DESCRIPTION
This PR adds the ability to configure custom images for the Terraform modules available in the repository. For example you could publish custom images to a private ECR repository like so:

```bash
scripts/build-image.sh -r 1234567890.dkr.ecr.us-west-2.amazonaws.com/aws-containers --tag custom --push
```

And reference these in Terraform by creating a `tfvars` file that has the following:

```hcl
container_image_overrides = {
  default_repository = "1234567890.dkr.ecr.us-west-2.amazonaws.com/aws-containers"
  default_tag        = "custom"
}
```