### PR TITLE
fix: Fix RabbitMQ username environment variable

### DIFF
--- a/deploy/kubernetes/charts/orders/templates/rabbitmq-secret.yaml
+++ b/deploy/kubernetes/charts/orders/templates/rabbitmq-secret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Values.rabbitmq.secret.name }}
 data:
   {{- if .Values.rabbitmq.secret.username }}
-  SPRING_RABBITMQ_USER: {{ .Values.rabbitmq.secret.username | b64enc | quote }}
+  SPRING_RABBITMQ_USERNAME: {{ .Values.rabbitmq.secret.username | b64enc | quote }}
   {{- end }}
   {{- if .Values.rabbitmq.secret.password }}
   SPRING_RABBITMQ_PASSWORD: {{ .Values.rabbitmq.secret.password | b64enc | quote }}


### PR DESCRIPTION
Environment variable for RabbitMQ username should be `SPRING_RABBITMQ_USERNAME`