### PR TITLE
chore: Bump EKS version in Terraform to 1.28

### DIFF
--- a/deploy/terraform/eks/default/main.tf
+++ b/deploy/terraform/eks/default/main.tf
@@ -52,7 +52,7 @@ module "retail_app_eks" {
   }
 
   environment_name      = var.environment_name
-  cluster_version       = "1.24"
+  cluster_version       = "1.28"
   vpc_id                = module.vpc.inner.vpc_id
   vpc_cidr              = module.vpc.inner.vpc_cidr_block
   subnet_ids            = module.vpc.inner.private_subnets

--- a/deploy/terraform/eks/minimal/main.tf
+++ b/deploy/terraform/eks/minimal/main.tf
@@ -33,7 +33,7 @@ module "retail_app_eks" {
   }
 
   environment_name      = var.environment_name
-  cluster_version       = "1.24"
+  cluster_version       = "1.28"
   vpc_id                = module.vpc.inner.vpc_id
   vpc_cidr              = module.vpc.inner.vpc_cidr_block
   subnet_ids            = module.vpc.inner.private_subnets


### PR DESCRIPTION
Upgrades the default version of EKS used in the Terraform configuration from 1.24 to 1.28