### PR TITLE
feat: Added proxy endpoint to UI service

### DIFF
--- a/src/orders/src/main/java/com/amazon/sample/orders/web/OrderController.java
+++ b/src/orders/src/main/java/com/amazon/sample/orders/web/OrderController.java
@@ -18,7 +18,6 @@
 
 package com.amazon.sample.orders.web;
 
-import com.amazon.sample.orders.entities.OrderEntity;
 import com.amazon.sample.orders.services.OrderService;
 import com.amazon.sample.orders.web.payload.*;
 
@@ -33,7 +32,7 @@ import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/orders")
-@Tag(name="orders")
+@Tag(name = "orders")
 @Slf4j
 public class OrderController {
 

--- a/src/ui/pom.xml
+++ b/src/ui/pom.xml
@@ -68,6 +68,11 @@
 			<artifactId>spring-boot-devtools</artifactId>
 		</dependency>
 		<dependency>
+				<groupId>org.springframework.cloud</groupId>
+				<artifactId>spring-cloud-gateway-webflux</artifactId>
+				<version>4.1.1</version>
+		</dependency>
+		<dependency>
 			<groupId>org.openapitools</groupId>
 			<artifactId>jackson-databind-nullable</artifactId>
 			<version>0.2.6</version>

--- a/src/ui/src/main/java/com/amazon/sample/ui/services/checkout/CheckoutService.java
+++ b/src/ui/src/main/java/com/amazon/sample/ui/services/checkout/CheckoutService.java
@@ -19,7 +19,6 @@
 package com.amazon.sample.ui.services.checkout;
 
 import com.amazon.sample.ui.services.checkout.model.Checkout;
-import com.amazon.sample.ui.services.checkout.model.CheckoutSubmitted;
 import com.amazon.sample.ui.services.checkout.model.CheckoutSubmittedResponse;
 import com.amazon.sample.ui.services.checkout.model.ShippingAddress;
 import reactor.core.publisher.Mono;

--- a/src/ui/src/main/java/com/amazon/sample/ui/web/BaseController.java
+++ b/src/ui/src/main/java/com/amazon/sample/ui/web/BaseController.java
@@ -18,7 +18,6 @@
 
 package com.amazon.sample.ui.web;
 
-import com.amazon.sample.ui.clients.carts.api.CartsApi;
 import com.amazon.sample.ui.services.Metadata;
 import com.amazon.sample.ui.services.carts.CartsService;
 import com.amazon.sample.ui.web.util.SessionIDUtil;
@@ -26,7 +25,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.server.reactive.ServerHttpRequest;
 import org.springframework.ui.Model;
-import org.springframework.web.server.ServerWebExchange;
 import reactor.util.retry.Retry;
 import reactor.util.retry.RetryBackoffSpec;
 
@@ -49,8 +47,8 @@ public class BaseController {
 
     protected static RetryBackoffSpec retrySpec(String path) {
         return Retry
-            .backoff(3, Duration.ofSeconds(1))
-            .doBeforeRetry(context -> log.warn("Retrying {}", path));
+                .backoff(3, Duration.ofSeconds(1))
+                .doBeforeRetry(context -> log.warn("Retrying {}", path));
     }
 
     protected void populateCommon(ServerHttpRequest request, Model model) {

--- a/src/ui/src/main/java/com/amazon/sample/ui/web/CatalogImageController.java
+++ b/src/ui/src/main/java/com/amazon/sample/ui/web/CatalogImageController.java
@@ -19,33 +19,28 @@
 package com.amazon.sample.ui.web;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.CacheControl;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.reactive.function.client.ExchangeStrategies;
-import org.springframework.web.reactive.function.client.WebClient;
 
 import com.amazon.sample.ui.services.assets.AssetsService;
 
 import reactor.core.publisher.Mono;
 
-import java.util.concurrent.TimeUnit;
-
 /**
- * This controller serves product images from the catalog backend, adding cache control headers along the way
+ * This controller serves product images from the catalog backend, adding cache
+ * control headers along the way
  */
 @RestController
 public class CatalogImageController {
 
-  private AssetsService assetsService;
+    private AssetsService assetsService;
 
-  public CatalogImageController(@Autowired AssetsService assetsService) {
-      this.assetsService = assetsService;
-  }
+    public CatalogImageController(@Autowired AssetsService assetsService) {
+        this.assetsService = assetsService;
+    }
 
     @GetMapping(value = "/assets/{image}", produces = MediaType.IMAGE_JPEG_VALUE)
     public Mono<ResponseEntity<byte[]>> catalogueImage(@PathVariable String image) {

--- a/src/ui/src/main/java/com/amazon/sample/ui/web/ProxyController.java
+++ b/src/ui/src/main/java/com/amazon/sample/ui/web/ProxyController.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT-0
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.amazon.sample.ui.web;
+
+import reactor.core.publisher.Mono;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.gateway.webflux.ProxyExchange;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/proxy")
+public class ProxyController {
+
+    @Value("${endpoints.catalog:}")
+    private String catalogEndpoint;
+
+    @Value("${endpoints.carts:}")
+    private String cartsEndpoint;
+
+    @Value("${endpoints.orders:}")
+    private String ordersEndpoint;
+
+    @Value("${endpoints.checkout:}")
+    private String checkoutEndpoint;
+
+    @GetMapping("/catalogue/**")
+    public Mono<ResponseEntity<byte[]>> catalogProxy(ProxyExchange<byte[]> proxy) throws Exception {
+        return doProxy(proxy, "catalog", catalogEndpoint);
+    }
+
+    @GetMapping("/carts/**")
+    public Mono<ResponseEntity<byte[]>> cartsProxy(ProxyExchange<byte[]> proxy) throws Exception {
+        return doProxy(proxy, "carts", cartsEndpoint);
+    }
+
+    @GetMapping("/checkout/**")
+    public Mono<ResponseEntity<byte[]>> checkoutProxy(ProxyExchange<byte[]> proxy) throws Exception {
+        return doProxy(proxy, "checkout", checkoutEndpoint);
+    }
+
+    @GetMapping("/orders/**")
+    public Mono<ResponseEntity<byte[]>> ordersProxy(ProxyExchange<byte[]> proxy) throws Exception {
+        return doProxy(proxy, "orders", checkoutEndpoint);
+    }
+
+    public Mono<ResponseEntity<byte[]>> doProxy(ProxyExchange<byte[]> proxy, String service, String endpoint)
+            throws Exception {
+        System.out.println("Endpoint is " + endpoint);
+        if (isEmpty(endpoint)) {
+            return Mono
+                    .just(new ResponseEntity<>(("Endpoint not provided for " + service).getBytes(),
+                            HttpStatus.NOT_FOUND));
+        }
+
+        String path = proxy.path("/proxy");
+        return proxy.uri(endpoint + path).header("Content-Type", "application/json").forward();
+    }
+
+    private boolean isEmpty(String check) {
+        return check.equals("false");
+    }
+}


### PR DESCRIPTION
This PR adds an endpoint `/proxy` to the UI service that forwards `GET` requests to the downstream service, allowing better accessibility of these services without exposing them with their own load balancers/ports.

For example sending this request to the UI service:

```
curl localhost:8888/proxy/catalogue
```

Will call `/catalogue' on the catalog service.

If an `ENDPOINT_` entry has not been configured for the relevant service the proxy endpoint will return a 404 with an error message.