### PR TITLE
fix: Updated compose syntax specifying file

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ cd dist/docker-compose
 Use `docker compose` to run the application containers:
 
 ```
-MYSQL_PASSWORD='<some password>' docker compose up -f dist/docker-compose/docker-compose.yml
+MYSQL_PASSWORD='<some password>' docker compose --file dist/docker-compose/docker-compose.yml up
 ```
 
 Open the frontend in a browser window:


### PR DESCRIPTION
*Issue #, if available:*
#444 

*Description of changes:*
Adjusted the `up` command after the file is defined so that the command executes successfully. Huzzah for small differences between docker-compose and docker compose.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
