### PR TITLE
feat: Added SQS implementation for orders events

### DIFF
--- a/src/orders/README.md
+++ b/src/orders/README.md
@@ -1,25 +1,32 @@
 # AWS Containers Retail Sample - Orders Service
 
 | Language | Persistence |
-|---|---|
-| Java | MySQL |
+| -------- | ----------- |
+| Java     | MySQL       |
 
 This service provides an API for storing orders. Data is stored in MySQL.
 
 ## Configuration
 
+The following Spring profiles are available:
+
+- `default`: Uses an in-memory implementation for messaging which logs the payload and discards the message
+- `sqs`: Publishes messages to an SQS topic configured with `MESSAGING_SQS_TOPIC` variable
+- `rabbitmq`: Publishes messages to a RabbitMQ topic configured with the `SPRING_RABBITMQ_` variables
+
 The following environment variables are available for configuring the service:
 
-| Name | Description | Default |
-|---|---|---|
-| `PORT` | The port which the server will listen on | `8080` |
-| `SPRING_DATASOURCE_WRITER_URL` | The URL for the MySQL database writer endpoint. Uses the format `jdbc:mariadb://<host>:<port>/<database>` | `""` |
-| `SPRING_DATASOURCE_WRITER_USERNAME` | The username for the MySQL database writer endpoint. | `""` |
-| `SPRING_DATASOURCE_WRITER_PASSWORD` | The password for the MySQL database writer endpoint. | `""` |
-| `SPRING_DATASOURCE_READER_URL` | The URL for the MySQL database reader endpoint. Uses the format `jdbc:mariadb://<host>:<port>/<database>` | `""` |
-| `SPRING_DATASOURCE_READER_USERNAME` | The username for the MySQL database reader endpoint. | `""` |
-| `SPRING_DATASOURCE_READER_PASSWORD` | The password for the MySQL database reader endpoint. | `""` |
-| `SPRING_RABBITMQ_ADDRESSES` | The address of the RabbitMQ endpoints. Uses the format `amqp://<endpoint>:<port>` | `""` |
+| Name                                | Description                                                                                               | Default |
+| ----------------------------------- | --------------------------------------------------------------------------------------------------------- | ------- |
+| `PORT`                              | The port which the server will listen on                                                                  | `8080`  |
+| `SPRING_DATASOURCE_WRITER_URL`      | The URL for the MySQL database writer endpoint. Uses the format `jdbc:mariadb://<host>:<port>/<database>` | `""`    |
+| `SPRING_DATASOURCE_WRITER_USERNAME` | The username for the MySQL database writer endpoint.                                                      | `""`    |
+| `SPRING_DATASOURCE_WRITER_PASSWORD` | The password for the MySQL database writer endpoint.                                                      | `""`    |
+| `SPRING_DATASOURCE_READER_URL`      | The URL for the MySQL database reader endpoint. Uses the format `jdbc:mariadb://<host>:<port>/<database>` | `""`    |
+| `SPRING_DATASOURCE_READER_USERNAME` | The username for the MySQL database reader endpoint.                                                      | `""`    |
+| `SPRING_DATASOURCE_READER_PASSWORD` | The password for the MySQL database reader endpoint.                                                      | `""`    |
+| `SPRING_RABBITMQ_ADDRESSES`         | The address of the RabbitMQ endpoints. Uses the format `amqp://<endpoint>:<port>`                         | `""`    |
+| `MESSAGING_SQS_TOPIC`               | The name of the SQS topic to publish events to.                                                           | `""`    |
 
 ## Running
 
@@ -28,6 +35,7 @@ There are two main options for running the service:
 ### Local
 
 Pre-requisites:
+
 - Java 17 installed
 
 Run the Spring Boot application like so:

--- a/src/orders/pom.xml
+++ b/src/orders/pom.xml
@@ -92,8 +92,16 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.17.0</version>
         </dependency>
+
+        <dependency>
+            <groupId>io.awspring.cloud</groupId>
+            <artifactId>spring-cloud-aws-starter</artifactId>
+		</dependency>
+		<dependency>
+            <groupId>io.awspring.cloud</groupId>
+            <artifactId>spring-cloud-aws-starter-sqs</artifactId>
+		</dependency>
 
         <dependency>
             <groupId>org.mapstruct</groupId>
@@ -129,6 +137,18 @@
             </exclusions>
         </dependency>
     </dependencies>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.awspring.cloud</groupId>
+                <artifactId>spring-cloud-aws-dependencies</artifactId>
+                <version>3.1.1</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <build>
         <plugins>

--- a/src/orders/src/main/java/com/amazon/sample/orders/config/messaging/InMemoryMessagingConfig.java
+++ b/src/orders/src/main/java/com/amazon/sample/orders/config/messaging/InMemoryMessagingConfig.java
@@ -25,7 +25,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 
 @Configuration
-@Profile("default")
+@Profile({"!rabbitmq", "!sqs"})
 public class InMemoryMessagingConfig {
     @Bean
     public MessagingProvider messagingProvider() {

--- a/src/orders/src/main/java/com/amazon/sample/orders/config/messaging/RabbitMQMessagingConfig.java
+++ b/src/orders/src/main/java/com/amazon/sample/orders/config/messaging/RabbitMQMessagingConfig.java
@@ -26,6 +26,7 @@ import org.springframework.amqp.rabbit.connection.ConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
 import org.springframework.amqp.rabbit.listener.RabbitListenerEndpointRegistrar;
 import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -35,7 +36,7 @@ import org.springframework.messaging.handler.annotation.support.MessageHandlerMe
 
 @Configuration
 @Profile("rabbitmq")
-public class RabbitMQMessagingConfig implements RabbitListenerConfigurer {
+public class RabbitMQMessagingConfig extends RabbitAutoConfiguration implements RabbitListenerConfigurer  {
     public static final String EXCHANGE_NAME = "orders-exchange";
 
     public static final String ORDERS_ORDERS_QUEUE = "orders-orders-queue";

--- a/src/orders/src/main/java/com/amazon/sample/orders/config/messaging/RabbitMQMessagingConfig.java
+++ b/src/orders/src/main/java/com/amazon/sample/orders/config/messaging/RabbitMQMessagingConfig.java
@@ -29,6 +29,7 @@ import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
 import org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import org.springframework.messaging.converter.MappingJackson2MessageConverter;
 import org.springframework.messaging.handler.annotation.support.DefaultMessageHandlerMethodFactory;
@@ -62,7 +63,8 @@ public class RabbitMQMessagingConfig extends RabbitAutoConfiguration implements 
     }
 
     @Bean
-    public RabbitTemplate rabbitTemplate(final ConnectionFactory connectionFactory) {
+    @Primary
+    public RabbitTemplate customRabbitTemplate(final ConnectionFactory connectionFactory) {
         final RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
         rabbitTemplate.setMessageConverter(producerJackson2MessageConverter());
         return rabbitTemplate;

--- a/src/orders/src/main/java/com/amazon/sample/orders/config/messaging/SqsMessagingConfig.java
+++ b/src/orders/src/main/java/com/amazon/sample/orders/config/messaging/SqsMessagingConfig.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT-0
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.amazon.sample.orders.config.messaging;
+
+import com.amazon.sample.orders.messaging.sqs.SqsMessagingProvider;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.awspring.cloud.sqs.operations.SqsTemplate;
+import software.amazon.awssdk.services.sqs.SqsAsyncClient;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+@Configuration
+@Profile("sqs")
+public class SqsMessagingConfig {
+
+    @Value("${messaging.sqs.topic}")
+    private String messageQueueTopic;
+
+    @Bean
+    public SqsAsyncClient sqsQueue() {
+        return SqsAsyncClient.builder().build();
+    }
+
+    @Bean
+    public SqsMessagingProvider messagingProvider(SqsAsyncClient amazonSqs, ObjectMapper mapper) {
+        return new SqsMessagingProvider(messageQueueTopic, SqsTemplate.newSyncTemplate(amazonSqs), mapper);
+    }
+}

--- a/src/orders/src/main/java/com/amazon/sample/orders/config/messaging/SqsMessagingConfig.java
+++ b/src/orders/src/main/java/com/amazon/sample/orders/config/messaging/SqsMessagingConfig.java
@@ -21,6 +21,8 @@ package com.amazon.sample.orders.config.messaging;
 import com.amazon.sample.orders.messaging.sqs.SqsMessagingProvider;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import io.awspring.cloud.autoconfigure.sqs.SqsAutoConfiguration;
+import io.awspring.cloud.autoconfigure.sqs.SqsProperties;
 import io.awspring.cloud.sqs.operations.SqsTemplate;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 
@@ -31,7 +33,11 @@ import org.springframework.context.annotation.Profile;
 
 @Configuration
 @Profile("sqs")
-public class SqsMessagingConfig {
+public class SqsMessagingConfig extends SqsAutoConfiguration {
+
+    public SqsMessagingConfig(SqsProperties sqsProperties) {
+      super(sqsProperties);
+    }
 
     @Value("${messaging.sqs.topic}")
     private String messageQueueTopic;

--- a/src/orders/src/main/java/com/amazon/sample/orders/messaging/sqs/SqsMessagingProvider.java
+++ b/src/orders/src/main/java/com/amazon/sample/orders/messaging/sqs/SqsMessagingProvider.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT-0
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.amazon.sample.orders.messaging.sqs;
+
+import com.amazon.sample.orders.messaging.MessagingProvider;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.awspring.cloud.sqs.operations.SqsOperations;
+
+public class SqsMessagingProvider implements MessagingProvider {
+
+    private final String messageQueueTopic;
+    private final SqsOperations blockingTemplate;
+    private final ObjectMapper mapper;
+
+    public SqsMessagingProvider(String messageQueueTopic, SqsOperations blockingTemplate, ObjectMapper mapper) {
+        this.blockingTemplate = blockingTemplate;
+        this.messageQueueTopic = messageQueueTopic;
+        this.mapper = mapper;
+    }
+
+    @Override
+    public void publishEvent(Object event) {
+        blockingTemplate.send(to -> {
+            try {
+                to.queue(messageQueueTopic)
+                    .payload(mapper.writeValueAsString(event))
+                    .delaySeconds(10);
+            } catch (JsonProcessingException e) {
+                e.printStackTrace();
+            }
+        });
+    }
+}

--- a/src/orders/src/main/resources/application-default.yml
+++ b/src/orders/src/main/resources/application-default.yml
@@ -1,3 +1,2 @@
 spring.autoconfigure.exclude:
   - org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration
-  - org.springframework.boot.autoconfigure.jms.activemq.ActiveMQAutoConfiguration

--- a/src/orders/src/main/resources/application-default.yml
+++ b/src/orders/src/main/resources/application-default.yml
@@ -1,2 +1,0 @@
-spring.autoconfigure.exclude:
-  - org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration

--- a/src/orders/src/main/resources/application-rabbitmq.yml
+++ b/src/orders/src/main/resources/application-rabbitmq.yml
@@ -1,2 +1,0 @@
-spring.autoconfigure.exclude:
-  - org.springframework.boot.autoconfigure.jms.activemq.ActiveMQAutoConfiguration

--- a/src/orders/src/main/resources/application.yml
+++ b/src/orders/src/main/resources/application.yml
@@ -2,7 +2,10 @@ management:
   endpoints:
     web:
       exposure:
-        include: '*'
+        include: "*"
+
+spring.autoconfigure.exclude:
+  - org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration
 
 server:
   port: ${port:8080}

--- a/src/orders/src/main/resources/application.yml
+++ b/src/orders/src/main/resources/application.yml
@@ -6,6 +6,7 @@ management:
 
 spring.autoconfigure.exclude:
   - org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration
+  - io.awspring.cloud.autoconfigure.sqs.SqsAutoConfiguration
 
 server:
   port: ${port:8080}

--- a/src/orders/src/test/java/com/amazon/sample/orders/OrdersApplicationTests.java
+++ b/src/orders/src/test/java/com/amazon/sample/orders/OrdersApplicationTests.java
@@ -20,8 +20,10 @@ package com.amazon.sample.orders;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("default")
 class OrdersApplicationTests {
 
 	@Test

--- a/src/orders/src/test/java/com/amazon/sample/orders/OrdersApplicationTests.java
+++ b/src/orders/src/test/java/com/amazon/sample/orders/OrdersApplicationTests.java
@@ -23,7 +23,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
-@ActiveProfiles("default")
 class OrdersApplicationTests {
 
 	@Test

--- a/src/orders/src/test/java/com/amazon/sample/orders/services/OrderServicePostgresTests.java
+++ b/src/orders/src/test/java/com/amazon/sample/orders/services/OrderServicePostgresTests.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -41,6 +42,7 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("default")
 public class OrderServicePostgresTests {
 
   @LocalServerPort

--- a/src/orders/src/test/java/com/amazon/sample/orders/services/OrderServicePostgresTests.java
+++ b/src/orders/src/test/java/com/amazon/sample/orders/services/OrderServicePostgresTests.java
@@ -42,7 +42,6 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-@ActiveProfiles("default")
 public class OrderServicePostgresTests {
 
   @LocalServerPort


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR adds an implementation of the messaging abstraction in the orders service that publishes messages to Amazon SQS. See the orders service README for more information.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
