### PR TITLE
fix: Improved mock catalog product names and descriptions

### DIFF
--- a/src/ui/src/main/java/com/amazon/sample/ui/services/catalog/MockCatalogService.java
+++ b/src/ui/src/main/java/com/amazon/sample/ui/services/catalog/MockCatalogService.java
@@ -34,7 +34,7 @@ public class MockCatalogService implements CatalogService {
         products = new HashMap<>();
 
         for(int i = 1; i < 21; i++) {
-            products.put(""+i, new Product(""+i, "product"+i, "product description "+i, 1, "/assets/img/sample_product.jpg", 123, new ArrayList<>()));
+            products.put(""+i, new Product(""+i, "Sample Product "+i, "This is a sample product description", 1, "/assets/img/sample_product.jpg", 123, new ArrayList<>()));
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Makes the product names and descriptions generated by the mock catalog service in the UI service a bit tidied. Instead of `product11` the generated name would be `Sample Product 11`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
