### PR TITLE
fix: Properly handle public ECR images in App Runner Terraform

### DIFF
--- a/deploy/terraform/apprunner/README.md
+++ b/deploy/terraform/apprunner/README.md
@@ -3,6 +3,7 @@
 This Terraform module creates all the necessary infrastructure and deploys the retail sample application on [AWS App Runner](https://aws.amazon.com/apprunner/).
 
 It provides:
+
 - VPC with public and private subnets
 - An App Runner service per application component
   - The UI service serves a public endpoint
@@ -14,6 +15,7 @@ NOTE: This will create resources in your AWS account which will incur costs. You
 ## Usage
 
 Pre-requisites for this are:
+
 - AWS, Terraform and kubectl installed locally
 - AWS CLI configured and authenticated with account to deploy to
 
@@ -27,7 +29,11 @@ terraform plan
 terraform apply
 ```
 
-The final command will prompt for confirmation that you wish to create the specified resources. After confirming the process will take at least 15 minutes to complete. You can then retrieve the HTTP endpoint for the UI from Terraform outputs:
+The final command will prompt for confirmation that you wish to create the specified resources. After confirming the process will take at least 15 minutes to complete.
+
+NOTE: Due to the complexity of the Terraform configuration there are intermitent failures. Please retry running `terraform apply` before raising an issue.
+
+You can then retrieve the HTTP endpoint for the UI from Terraform outputs:
 
 ```shell
 terraform output -raw application_url
@@ -41,12 +47,12 @@ This section documents the variables and outputs of the Terraform configuration.
 
 ### Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| `environment_name` | Name of the environment which will be used for all resources created | `string` | `retail-store-ar` | yes |
+| Name               | Description                                                          | Type     | Default           | Required |
+| ------------------ | -------------------------------------------------------------------- | -------- | ----------------- | :------: |
+| `environment_name` | Name of the environment which will be used for all resources created | `string` | `retail-store-ar` |   yes    |
 
 ### Outputs
 
-| Name | Description |
-|------|-------------|
+| Name              | Description                               |
+| ----------------- | ----------------------------------------- |
 | `application_url` | URL where the application can be accessed |

--- a/deploy/terraform/lib/apprunner/assets.tf
+++ b/deploy/terraform/lib/apprunner/assets.tf
@@ -13,7 +13,7 @@ module "app_runner_assets" {
       image_repository_type = var.image_repository_type
     }
     authentication_configuration = {
-      access_role_arn = aws_iam_role.ecr_access.arn
+      access_role_arn = local.access_role_arn
     }
   }
 

--- a/deploy/terraform/lib/apprunner/carts.tf
+++ b/deploy/terraform/lib/apprunner/carts.tf
@@ -10,8 +10,6 @@ module "app_runner_carts" {
         port = 8080
         runtime_environment_variables = {
           CARTS_DYNAMODB_TABLENAME = var.carts_dynamodb_table_name
-        }
-        runtime_environment_variables = {
           SPRING_PROFILES_ACTIVE = "dynamodb"
         }
       }
@@ -19,7 +17,7 @@ module "app_runner_carts" {
       image_repository_type = var.image_repository_type
     }
     authentication_configuration = {
-      access_role_arn = aws_iam_role.ecr_access.arn
+      access_role_arn = local.access_role_arn
     }
   }
 

--- a/deploy/terraform/lib/apprunner/catalog.tf
+++ b/deploy/terraform/lib/apprunner/catalog.tf
@@ -23,7 +23,7 @@ resource "aws_apprunner_service" "catalog" {
       image_repository_type = var.image_repository_type
     }
     authentication_configuration {
-      access_role_arn = aws_iam_role.ecr_access.arn
+      access_role_arn = local.access_role_arn
     }
   }
 

--- a/deploy/terraform/lib/apprunner/checkout.tf
+++ b/deploy/terraform/lib/apprunner/checkout.tf
@@ -17,7 +17,7 @@ module "app_runner_checkout" {
       image_repository_type = var.image_repository_type
     }
     authentication_configuration = {
-      access_role_arn = aws_iam_role.ecr_access.arn
+      access_role_arn = local.access_role_arn
     }
   }
 

--- a/deploy/terraform/lib/apprunner/common.tf
+++ b/deploy/terraform/lib/apprunner/common.tf
@@ -52,3 +52,7 @@ resource "aws_iam_role_policy_attachment" "ecr_access" {
   role       = aws_iam_role.ecr_access.name
   policy_arn = data.aws_iam_policy.ecr_access.arn
 }
+
+locals {
+  access_role_arn = var.image_repository_type == "ECR_PUBLIC" ? null : aws_iam_role.ecr_access.arn
+}

--- a/deploy/terraform/lib/apprunner/orders.tf
+++ b/deploy/terraform/lib/apprunner/orders.tf
@@ -28,7 +28,7 @@ resource "aws_apprunner_service" "orders" {
     }
 
     authentication_configuration {
-      access_role_arn = aws_iam_role.ecr_access.arn
+      access_role_arn = local.access_role_arn
     }
   }
 

--- a/deploy/terraform/lib/apprunner/ui.tf
+++ b/deploy/terraform/lib/apprunner/ui.tf
@@ -20,7 +20,7 @@ module "app_runner_ui" {
       image_repository_type = var.image_repository_type
     }
     authentication_configuration = {
-      access_role_arn = aws_iam_role.ecr_access.arn
+      access_role_arn = local.access_role_arn
     }
   }
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* The App Runner Terraform was failing to deploy properly with ECR Public images due to providing authentication configuration only suitable for ECR private repositories. This authentication configuration is now passed in conditionally depending on the repository type.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
