### PR TITLE
fix: Orders helm chart should enable rabbitmq messaging

### DIFF
--- a/deploy/kubernetes/charts/orders/templates/configmap.yml
+++ b/deploy/kubernetes/charts/orders/templates/configmap.yml
@@ -4,7 +4,7 @@ kind: ConfigMap
 metadata:
   name: {{ include "orders.configMapName" . }}
 data:
-  SPRING_PROFILES_ACTIVE: rabbitmq
+  RETAIL_ORDERS_MESSAGING_PROVIDER: rabbitmq
   SPRING_DATASOURCE_URL: {{ include "orders.postgresql.endpoint" . }}
   SPRING_RABBITMQ_ADDRESSES: {{ include "orders.rabbitmq.addresses" . }}
 {{- end }}


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

The orders helm chart now uses the new setting as of 0.8.0 to enable rabbitmq

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
