### PR TITLE
fix: added "aws-load-balancer-scheme" annotation to UI Service

### DIFF
--- a/dist/kubernetes/deploy.yaml
+++ b/dist/kubernetes/deploy.yaml
@@ -1068,6 +1068,8 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
+  annotations:
+      service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
   selector:
     app.kubernetes.io/name: ui
     app.kubernetes.io/instance: ui

--- a/dist/kubernetes/deploy.yaml
+++ b/dist/kubernetes/deploy.yaml
@@ -1054,6 +1054,8 @@ apiVersion: v1
 kind: Service
 metadata:
   name: ui
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
   labels:
     helm.sh/chart: ui-0.0.1
     app.kubernetes.io/name: ui
@@ -1068,8 +1070,6 @@ spec:
       targetPort: http
       protocol: TCP
       name: http
-  annotations:
-      service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
   selector:
     app.kubernetes.io/name: ui
     app.kubernetes.io/instance: ui


### PR DESCRIPTION
*Issue #, if available:*
During the deployment of the Helm chart, I observed that the UI service was creating an Internal Load Balancer. Although a public URL was provided, the service was inaccessible from the internet.

*Description of changes:*
To address this, I have added the annotation "aws-load-balancer-scheme" to "internet-facing" to the deploy.yaml file in the Kubernetes configuration.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
