### PR TITLE
feat: Added stress and status utility endpoints

### DIFF
--- a/src/ui/README.md
+++ b/src/ui/README.md
@@ -1,8 +1,8 @@
 # AWS Containers Retail Sample - UI Service
 
 | Language | Persistence |
-|---|---|
-| Java | N/A |
+| -------- | ----------- |
+| Java     | N/A         |
 
 This service provides the frontend for the retail store, serving the HTML UI and aggregating calls to the backend API components.
 
@@ -10,16 +10,25 @@ This service provides the frontend for the retail store, serving the HTML UI and
 
 The following environment variables are available for configuring the service:
 
-| Name | Description | Default |
-|---|---|---|
-| `PORT` | The port which the server will listen on | `8080` |
-| `ENDPOINTS_CATALOG` | The endpoint of the catalog API. If set to `false` uses a mock implementation | `false` |
-| `ENDPOINTS_CARTS` | The endpoint of the carts API. If set to `false` uses a mock implementation | `false` |
-| `ENDPOINTS_ORDERS` | The endpoint of the orders API. If set to `false` uses a mock implementation | `false` |
-| `ENDPOINTS_CHECKOUT` | The endpoint of the checkout API. If set to `false` uses a mock implementation | `false` |
-| `ENDPOINTS_ASSETS` | The endpoint of the assets service. If set to `false` uses a mock implementation | `false` |
-| `ENDPOINTS_HTTP_KEEPALIVE` | Set to false to disable HTTP keepalive on requests to backend services | `true` |
-| `RETAIL_UI_BANNER` | Sets text for a banner which will be displayed at the top of the UI on every page | `""` |
+| Name                       | Description                                                                       | Default |
+| -------------------------- | --------------------------------------------------------------------------------- | ------- |
+| `PORT`                     | The port which the server will listen on                                          | `8080`  |
+| `ENDPOINTS_CATALOG`        | The endpoint of the catalog API. If set to `false` uses a mock implementation     | `false` |
+| `ENDPOINTS_CARTS`          | The endpoint of the carts API. If set to `false` uses a mock implementation       | `false` |
+| `ENDPOINTS_ORDERS`         | The endpoint of the orders API. If set to `false` uses a mock implementation      | `false` |
+| `ENDPOINTS_CHECKOUT`       | The endpoint of the checkout API. If set to `false` uses a mock implementation    | `false` |
+| `ENDPOINTS_ASSETS`         | The endpoint of the assets service. If set to `false` uses a mock implementation  | `false` |
+| `ENDPOINTS_HTTP_KEEPALIVE` | Set to false to disable HTTP keepalive on requests to backend services            | `true`  |
+| `RETAIL_UI_BANNER`         | Sets text for a banner which will be displayed at the top of the UI on every page | `""`    |
+
+## Endpoints
+
+Several "utility" endpoints are provided with useful functionality for various scenarios:
+
+| Method | Name                           | Description                                                                 |
+| ------ | ------------------------------ | --------------------------------------------------------------------------- |
+| `GET`  | `/utility/stress/{iterations}` | Stress the CPU with the number of iterations increasing the CPU consumption |
+| `GET`  | `/utility/status/{code}`       | Returns HTTP response with given HTTP status code                           |
 
 ## Running
 
@@ -28,6 +37,7 @@ There are two main options for running the service:
 ### Local
 
 Pre-requisites:
+
 - Java 17 installed
 
 Run the Spring Boot application like so:

--- a/src/ui/src/main/java/com/amazon/sample/ui/web/UtilityController.java
+++ b/src/ui/src/main/java/com/amazon/sample/ui/web/UtilityController.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT-0
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.amazon.sample.ui.web;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Controller
+@RequestMapping("/utility")
+public class UtilityController {
+
+    @GetMapping("/stress/{iterations}")
+    @ResponseBody
+    public double stress(@PathVariable int iterations) {
+        return monteCarloPi(iterations);
+    }
+
+    private double monteCarloPi(int iterations) {
+        int inside = 0;
+        for (int i = 0; i < iterations; i++) {
+            double x = Math.random();
+            double y = Math.random();
+            if (Math.sqrt(x * x + y * y) < 1.0) {
+                inside++;
+            }
+        }
+        return 4.0 * inside / iterations;
+    }
+
+    @GetMapping("/status/{code}")
+    public ResponseEntity<String> status(@PathVariable int code) {
+        return ResponseEntity.status(code).body("OK");
+    }
+}


### PR DESCRIPTION
*Issue #, if available:* Related to #596

*Description of changes:*

Adds two HTTP endpoints to the UI component that are useful for certain demo scenarios:

`/utility/stress/{iterations}` generates CPU load
`/utility/status/{code}` returns an HTTP response with the given HTTP status code

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
