### PR TITLE
chore: multi-stage build for checkout

### DIFF
--- a/src/checkout/Dockerfile
+++ b/src/checkout/Dockerfile
@@ -1,3 +1,12 @@
+FROM node:20-alpine AS build
+WORKDIR /usr/src/app
+COPY --chown=node:node package*.json ./
+COPY --chown=node:node . .
+RUN npm run build
+RUN npm ci -f && npm cache clean --force
+USER node
+
+
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 
 # We tell DNF not to install Recommends and Suggests packages, which are
@@ -26,12 +35,7 @@ RUN useradd \
 WORKDIR /app
 USER appuser
 
-COPY --chown=appuser:appuser package.json .
-COPY --chown=appuser:appuser package-lock.json .
-
-RUN npm ci
-
-ADD . /app
-RUN npm run build
+COPY --chown=node:node --from=build /usr/src/app/node_modules ./node_modules
+COPY --chown=node:node --from=build /usr/src/app/dist ./dist
 
 ENTRYPOINT [ "node", "dist/main.js" ]

--- a/src/checkout/Dockerfile
+++ b/src/checkout/Dockerfile
@@ -2,8 +2,8 @@ FROM node:20-alpine AS build
 WORKDIR /usr/src/app
 COPY --chown=node:node package*.json ./
 COPY --chown=node:node . .
+RUN npm ci -f
 RUN npm run build
-RUN npm ci -f && npm cache clean --force
 USER node
 
 
@@ -14,7 +14,6 @@ FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 # packages as minimal as possible.
 RUN dnf --setopt=install_weak_deps=False install -q -y \
     nodejs20 \
-    npm \
     shadow-utils \
     && \
     dnf clean all


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR changes the Dockerfile for the checkout component to use a multi-stage build. This gives more flexibility in the version of `npm` used to build the application without it being package in the final distributed image.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
