### PR TITLE
setting up the java apps for auto-instrumentation

### DIFF
--- a/src/cart/Dockerfile
+++ b/src/cart/Dockerfile
@@ -38,8 +38,6 @@ RUN dnf --setopt=install_weak_deps=False install -q -y \
     && \
     dnf clean all
 
-ARG aws_opentelemetry_agent_version=1.24.0
-
 ENV APPUSER=appuser
 ENV APPUID=1000
 ENV APPGID=1000
@@ -50,11 +48,6 @@ RUN useradd \
     --user-group \
     --uid "$APPUID" \
     "$APPUSER"
-
-RUN curl -L https://github.com/aws-observability/aws-otel-java-instrumentation/releases/download/v${aws_opentelemetry_agent_version}/aws-opentelemetry-agent.jar -o /opt/aws-opentelemetry-agent.jar && \
-    curl -L https://raw.githubusercontent.com/aws-observability/aws-otel-java-instrumentation/v${aws_opentelemetry_agent_version}/licenses/licenses.md -o aws-opentelemetry-agent-licenses.md
-ENV JAVA_TOOL_OPTIONS=-javaagent:/opt/aws-opentelemetry-agent.jar
-ENV OTEL_JAVAAGENT_ENABLED=false
 
 WORKDIR /app
 USER appuser

--- a/src/cart/Dockerfile
+++ b/src/cart/Dockerfile
@@ -49,6 +49,8 @@ RUN useradd \
     --uid "$APPUID" \
     "$APPUSER"
 
+RUN curl -L https://github.com/aws-observability/aws-otel-java-instrumentation/releases/latest/download/aws-opentelemetry-agent.jar -o /opt/aws-opentelemetry-agent.jar
+
 WORKDIR /app
 USER appuser
 

--- a/src/orders/Dockerfile
+++ b/src/orders/Dockerfile
@@ -38,8 +38,6 @@ RUN dnf --setopt=install_weak_deps=False install -q -y \
     && \
     dnf clean all
 
-ARG aws_opentelemetry_agent_version=1.24.0
-
 ENV APPUSER=appuser
 ENV APPUID=1000
 ENV APPGID=1000
@@ -50,11 +48,6 @@ RUN useradd \
     --user-group \
     --uid "$APPUID" \
     "$APPUSER"
-
-RUN curl -L https://github.com/aws-observability/aws-otel-java-instrumentation/releases/download/v${aws_opentelemetry_agent_version}/aws-opentelemetry-agent.jar -o /opt/aws-opentelemetry-agent.jar && \
-    curl -L https://raw.githubusercontent.com/aws-observability/aws-otel-java-instrumentation/v${aws_opentelemetry_agent_version}/licenses/licenses.md -o aws-opentelemetry-agent-licenses.md
-ENV JAVA_TOOL_OPTIONS=-javaagent:/opt/aws-opentelemetry-agent.jar
-ENV OTEL_JAVAAGENT_ENABLED=false
 
 WORKDIR /app
 USER appuser

--- a/src/orders/Dockerfile
+++ b/src/orders/Dockerfile
@@ -49,6 +49,8 @@ RUN useradd \
     --uid "$APPUID" \
     "$APPUSER"
 
+RUN curl -L https://github.com/aws-observability/aws-otel-java-instrumentation/releases/latest/download/aws-opentelemetry-agent.jar -o /opt/aws-opentelemetry-agent.jar
+
 WORKDIR /app
 USER appuser
 

--- a/src/ui/Dockerfile
+++ b/src/ui/Dockerfile
@@ -36,8 +36,6 @@ RUN dnf --setopt=install_weak_deps=False install -q -y \
     && \
     dnf clean all
 
-ARG aws_opentelemetry_agent_version=1.24.0
-
 ENV APPUSER=appuser
 ENV APPUID=1000
 ENV APPGID=1000
@@ -48,11 +46,6 @@ RUN useradd \
     --user-group \
     --uid "$APPUID" \
     "$APPUSER"
-
-RUN curl -L https://github.com/aws-observability/aws-otel-java-instrumentation/releases/download/v${aws_opentelemetry_agent_version}/aws-opentelemetry-agent.jar -o /opt/aws-opentelemetry-agent.jar && \
-    curl -L https://raw.githubusercontent.com/aws-observability/aws-otel-java-instrumentation/v${aws_opentelemetry_agent_version}/licenses/licenses.md -o aws-opentelemetry-agent-licenses.md
-ENV JAVA_TOOL_OPTIONS=-javaagent:/opt/aws-opentelemetry-agent.jar
-ENV OTEL_JAVAAGENT_ENABLED=false
 
 WORKDIR /app
 USER appuser

--- a/src/ui/Dockerfile
+++ b/src/ui/Dockerfile
@@ -47,6 +47,8 @@ RUN useradd \
     --uid "$APPUID" \
     "$APPUSER"
 
+RUN curl -L https://github.com/aws-observability/aws-otel-java-instrumentation/releases/latest/download/aws-opentelemetry-agent.jar -o /opt/aws-opentelemetry-agent.jar
+
 WORKDIR /app
 USER appuser
 


### PR DESCRIPTION
The partial OTEL configs in the dockerfile for the Java services is causing issues at times. We will do this via add-on in EKS and task def in ECS
Description of changes:
This commit removes the configuration of the OTEL metrics from the orders, cart and UI services.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
