### PR TITLE
fix: Update aws_mq_broker to a supported engine_version

### DIFF
--- a/deploy/terraform/lib/dependencies/mq.tf
+++ b/deploy/terraform/lib/dependencies/mq.tf
@@ -13,7 +13,7 @@ resource "aws_mq_broker" "mq" {
   broker_name = "${var.environment_name}-orders-broker"
 
   engine_type         = "RabbitMQ"
-  engine_version      = "3.10.10"
+  engine_version      = "3.11.16"
   host_instance_type  = "mq.t3.micro"
   deployment_mode     = "SINGLE_INSTANCE"
   subnet_ids          = [var.subnet_ids[0]]


### PR DESCRIPTION
Issue #, if available: 665
Description of changes: Update TF resource aws_mq_broker to a supported engine_version. 3.11.16 is current.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
