### PR TITLE
fix: Enable full functionality curl for ui & orders

### DIFF
--- a/src/orders/Dockerfile
+++ b/src/orders/Dockerfile
@@ -38,6 +38,11 @@ RUN dnf --setopt=install_weak_deps=False install -q -y \
     && \
     dnf clean all
 
+# use curl-full to use "telnet://" scheme
+# https://docs.aws.amazon.com/linux/al2023/ug/curl-minimal.html
+RUN dnf -q -y swap libcurl-minimal libcurl-full \
+    && dnf -q -y swap curl-minimal curl-full
+
 ARG aws_opentelemetry_agent_version=1.24.0
 
 ENV APPUSER=appuser

--- a/src/ui/Dockerfile
+++ b/src/ui/Dockerfile
@@ -36,6 +36,11 @@ RUN dnf --setopt=install_weak_deps=False install -q -y \
     && \
     dnf clean all
 
+# use curl-full to use "telnet://" scheme
+# https://docs.aws.amazon.com/linux/al2023/ug/curl-minimal.html
+RUN dnf -q -y swap libcurl-minimal libcurl-full \
+    && dnf -q -y swap curl-minimal curl-full
+
 ARG aws_opentelemetry_agent_version=1.24.0
 
 ENV APPUSER=appuser


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Amazon Linux 2023 [now have curl-minimal installed by default](https://docs.aws.amazon.com/linux/al2023/ug/curl-minimal.html), which don't support scheme other than http ones.
As the Network Policies modules workshop leverage on it: 
https://eksworkshop.com/docs/networking/vpc-cni/network-policies/egress & https://eksworkshop.com/docs/networking/vpc-cni/network-policies/ingress

swapping to curl-full to have `telnet://` supported.
Other alternatives are using `/dev/tcp` or `netcat` for doing connectivity tests.

Note: the test of the workshop module is not failing as the [command tested expect to fail](https://github.com/aws-samples/eks-workshop-v2/blob/main/website/docs/networking/vpc-cni/network-policies/egress.md?plain=1#L65).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
