### PR TITLE
feat: UI home page renders instead of redirect

### DIFF
--- a/src/ui/src/main/java/com/amazon/sample/ui/web/HomeController.java
+++ b/src/ui/src/main/java/com/amazon/sample/ui/web/HomeController.java
@@ -39,8 +39,8 @@ public class HomeController extends BaseController {
     }
 
     @GetMapping("/")
-    public String index() {
-        return "redirect:/home";
+    public String index(final Model model, final ServerHttpRequest request) {
+        return home(model, request);
     }
 
     @GetMapping("/home")


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Originally accessing the index page `/` of the UI component would cause an HTTP redirect to `/home`. Functionally this was fine but causes some confusion when deploying the application where things like health checks expect a 200 response.

This change causes the index page to just render the same response as `/home` without the redirect.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
