### PR TITLE
fix: Use consistent DynamoDB local image version

### DIFF
--- a/deploy/kubernetes/charts/carts/values.yaml
+++ b/deploy/kubernetes/charts/carts/values.yaml
@@ -82,7 +82,7 @@ dynamodb:
   image:
     repository: amazon/dynamodb-local
     pullPolicy: IfNotPresent
-    tag: "1.13.1"
+    tag: "1.20.0"
 
   service:
     type: ClusterIP

--- a/src/cart/docker-compose.yml
+++ b/src/cart/docker-compose.yml
@@ -37,7 +37,7 @@ services:
         condition: service_healthy
 
   carts-db:
-    image: amazon/dynamodb-local:1.13.1
+    image: amazon/dynamodb-local:1.20.0
     hostname: carts-db
     restart: always
     cap_drop:

--- a/src/cart/src/test/java/com/amazon/sample/carts/services/DynamoDBCartServiceTests.java
+++ b/src/cart/src/test/java/com/amazon/sample/carts/services/DynamoDBCartServiceTests.java
@@ -59,7 +59,7 @@ public class DynamoDBCartServiceTests extends AbstractServiceTests {
 
     @Container
     public static GenericContainer dynamodbContainer =
-            new GenericContainer<>("amazon/dynamodb-local:1.13.3")
+            new GenericContainer<>("amazon/dynamodb-local:1.20.0")
                     .withExposedPorts(DYNAMODB_PORT);
 
     @Override


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Sets all the DynamoDB local image versions to 1.20.0 for consistency. This also ensures that all instances use a version that is arm64 compatible.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
