### PR TITLE
fix: Handle multiple ingresses in UI helm chart

### DIFF
--- a/deploy/kubernetes/charts/ui/templates/ingress.yaml
+++ b/deploy/kubernetes/charts/ui/templates/ingress.yaml
@@ -1,3 +1,6 @@
+{{- if and .Values.ingress.enabled .Values.ingresses }}
+  {{- fail "Cannot set both ingress.enabled and ingresses" }}
+{{- end }}
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "ui.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}
@@ -50,4 +53,60 @@ spec:
                 port:
                   number: {{ $svcPort }}
     {{- end }}
+{{- end }}
+{{- if .Values.ingresses }}
+{{- $fullName := include "ui.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- range .Values.ingresses }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}-{{ .name }}
+  labels:
+    {{- include "ui.labels" $ | nindent 4 }}
+  {{- with .annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .className }}
+  ingressClassName: {{ .className }}
+  {{- end }}
+  {{- if .tls }}
+  tls:
+    {{- range .tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- if .hosts }}
+    {{- range .hosts }}
+    - host: {{ . | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+    {{- end }}
+    {{- else }}
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+    {{- end }}
+{{- end }}
 {{- end }}

--- a/deploy/kubernetes/charts/ui/values.yaml
+++ b/deploy/kubernetes/charts/ui/values.yaml
@@ -84,6 +84,23 @@ endpoints:
 ingress:
   enabled: false
   # className: ""
+  annotations: {}
+  #   alb.ingress.kubernetes.io/scheme: internet-facing
+  #   alb.ingress.kubernetes.io/target-type: ip
+  #   alb.ingress.kubernetes.io/healthcheck-path: /actuator/health/liveness
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+  hosts: []
+  #  - "chart-example.local"
+
+ingresses: []
+  # - name: default
+  #   className: ""
+  #   hosts: []
+  #   annotations: {}
+  #   tls: []
 
 istio:
   enabled: false


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Allow the UI helm chart to express multiple Ingress objects. This is useful to allow blue/green ALB migrations.

```yaml
ingresses:
  - name: default
    className: ""
    hosts: []
    annotations: {}
    tls: []
```

Only `ingress` or `ingresses` can be set, not both. This is to prevent confusion about usage.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
