### PR TITLE
fix: Safely remove cart items

### DIFF
--- a/src/ui/src/main/java/com/amazon/sample/ui/services/carts/model/Cart.java
+++ b/src/ui/src/main/java/com/amazon/sample/ui/services/carts/model/Cart.java
@@ -47,11 +47,7 @@ public class Cart {
   }
 
   public void removeItem(String id) {
-    for (CartItem i : items) {
-      if (i.getId().equals(id)) {
-        this.items.remove(i);
-      }
-    }
+    items.removeIf(item -> item.getId().equals(id));
   }
 
   public int getSubtotal() {


### PR DESCRIPTION
Closes: #751 

The `removeIf` method handles the safe removal of elements, which in this case checks if the item ID matches the one we want to remove.
Without this, removing the last element result in `ConcurrentModificationException`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
