### PR TITLE
feat: Allow serving sample images from filesystem

### DIFF
--- a/src/ui/README.md
+++ b/src/ui/README.md
@@ -10,24 +10,25 @@ This service provides the frontend for the retail store, serving the HTML UI and
 
 The following environment variables are available for configuring the service:
 
-| Name                              | Description                                                                    | Default                 |
-| --------------------------------- | ------------------------------------------------------------------------------ | ----------------------- |
-| `PORT`                            | The port which the server will listen on                                       | `8080`                  |
-| `RETAIL_UI_THEME`                 | Name of the theme for the UI, valid values are `default`, `green`, `orange`    | `"default"`             |
-| `RETAIL_UI_DISABLE_DEMO_WARNINGS` | Disable the UI messages warning about demonstration content                    | `false`                 |
-| `RETAIL_UI_ENDPOINTS_CATALOG`     | The endpoint of the catalog API. If set to `false` uses a mock implementation  | `false`                 |
-| `RETAIL_UI_ENDPOINTS_CARTS`       | The endpoint of the carts API. If set to `false` uses a mock implementation    | `false`                 |
-| `RETAIL_UI_ENDPOINTS_ORDERS`      | The endpoint of the orders API. If set to `false` uses a mock implementation   | `false`                 |
-| `RETAIL_UI_ENDPOINTS_CHECKOUT`    | The endpoint of the checkout API. If set to `false` uses a mock implementation | `false`                 |
-| `RETAIL_UI_CHAT_ENABLED`          | Enable the chat bot UI                                                         | `false`                 |
-| `RETAIL_UI_CHAT_PROVIDER`         | The chat provider to use, value values are `bedrock`, `openai`, `mock`         | `""`                    |
-| `RETAIL_UI_CHAT_MODEL`            | The chat model to use, depends on the provider.                                | `""`                    |
-| `RETAIL_UI_CHAT_TEMPERATURE`      | Model temperature                                                              | `0.6`                   |
-| `RETAIL_UI_CHAT_MAX_TOKENS`       | Model maximum response tokens                                                  | `300`                   |
-| `RETAIL_UI_CHAT_PROMPT`           | Model system prompt                                                            | `(see source)`          |
-| `RETAIL_UI_CHAT_BEDROCK_REGION`   | Amazon Bedrock region                                                          | `""`                    |
-| `RETAIL_UI_CHAT_OPENAI_BASE_URL`  | Base URL for OpenAI endpoint                                                   | `http://localhost:8888` |
-| `RETAIL_UI_CHAT_OPENAI_API_KEY`   | API key for OpenAI endpoint                                                    | `""`                    |
+| Name                              | Description                                                                                            | Default                 |
+| --------------------------------- | ------------------------------------------------------------------------------------------------------ | ----------------------- |
+| `PORT`                            | The port which the server will listen on                                                               | `8080`                  |
+| `RETAIL_UI_THEME`                 | Name of the theme for the UI, valid values are `default`, `green`, `orange`                            | `"default"`             |
+| `RETAIL_UI_DISABLE_DEMO_WARNINGS` | Disable the UI messages warning about demonstration content                                            | `false`                 |
+| `RETAIL_UI_PRODUCT_IMAGES_PATH`   | Overrides the location where the sample product images are sourced from to use the specified file path | ``                      |
+| `RETAIL_UI_ENDPOINTS_CATALOG`     | The endpoint of the catalog API. If set to `false` uses a mock implementation                          | `false`                 |
+| `RETAIL_UI_ENDPOINTS_CARTS`       | The endpoint of the carts API. If set to `false` uses a mock implementation                            | `false`                 |
+| `RETAIL_UI_ENDPOINTS_ORDERS`      | The endpoint of the orders API. If set to `false` uses a mock implementation                           | `false`                 |
+| `RETAIL_UI_ENDPOINTS_CHECKOUT`    | The endpoint of the checkout API. If set to `false` uses a mock implementation                         | `false`                 |
+| `RETAIL_UI_CHAT_ENABLED`          | Enable the chat bot UI                                                                                 | `false`                 |
+| `RETAIL_UI_CHAT_PROVIDER`         | The chat provider to use, value values are `bedrock`, `openai`, `mock`                                 | `""`                    |
+| `RETAIL_UI_CHAT_MODEL`            | The chat model to use, depends on the provider.                                                        | `""`                    |
+| `RETAIL_UI_CHAT_TEMPERATURE`      | Model temperature                                                                                      | `0.6`                   |
+| `RETAIL_UI_CHAT_MAX_TOKENS`       | Model maximum response tokens                                                                          | `300`                   |
+| `RETAIL_UI_CHAT_PROMPT`           | Model system prompt                                                                                    | `(see source)`          |
+| `RETAIL_UI_CHAT_BEDROCK_REGION`   | Amazon Bedrock region                                                                                  | `""`                    |
+| `RETAIL_UI_CHAT_OPENAI_BASE_URL`  | Base URL for OpenAI endpoint                                                                           | `http://localhost:8888` |
+| `RETAIL_UI_CHAT_OPENAI_API_KEY`   | API key for OpenAI endpoint                                                                            | `""`                    |
 
 ## Endpoints
 

--- a/src/ui/src/main/java/com/amazon/sample/ui/config/WebConfig.java
+++ b/src/ui/src/main/java/com/amazon/sample/ui/config/WebConfig.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT-0
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.amazon.sample.ui.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.config.ResourceHandlerRegistry;
+import org.springframework.web.reactive.config.WebFluxConfigurer;
+
+@Configuration
+public class WebConfig implements WebFluxConfigurer {
+
+  @Value("${retail.ui.product-images-path}")
+  private String productImagesPath;
+
+  @Override
+  public void addResourceHandlers(ResourceHandlerRegistry registry) {
+    System.out.println(this.productImagesPath);
+
+    if (this.productImagesPath != null && !this.productImagesPath.isEmpty()) {
+      registry
+        .addResourceHandler("/assets/img/products/**")
+        .addResourceLocations("file:" + this.productImagesPath);
+    }
+  }
+}

--- a/src/ui/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/ui/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -11,6 +11,11 @@
       "description": "Disable the UI messages warning about demonstration content"
     },
     {
+      "name": "retail.ui.product-images-path",
+      "type": "java.lang.String",
+      "description": "Overrides the location where the sample product images are sourced from to use the specified file path"
+    },
+    {
       "name": "retail.ui.endpoints.catalog",
       "type": "java.lang.String",
       "description": "HTTP endpoint for the catalog service"

--- a/src/ui/src/main/resources/application.yml
+++ b/src/ui/src/main/resources/application.yml
@@ -12,6 +12,7 @@ retail:
   ui:
     theme: default
     disable-demo-warnings: false
+    product-images-path: # /mnt/products
     endpoints:
       catalog: # http://localhost:8081
       carts: # http://localhost:8082


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

By default sample product images are served from the UI component classpath as resources.

This PR allows the images to be optionally served from the filesystem.

Set through an environment variable like so:

```
RETAIL_UI_PRODUCT_IMAGES_PATH=/some/directory
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
