### PR TITLE
fix: use nlb instead of classic lb for ui service

### DIFF
--- a/src/ui/chart/values.yaml
+++ b/src/ui/chart/values.yaml
@@ -40,7 +40,9 @@ securityContext:
 service:
   type: ClusterIP
   port: 80
-  # annotations: {}
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+    service.beta.kubernetes.io/aws-load-balancer-scheme: internet-facing
   # loadBalancerClass: ""
   # nodePort: 30000
 


### PR DESCRIPTION
*Issue:*

The current UI service YAML deployment creates a classic load balancer which is essentially deprecated. 

*Description of changes:*

This simply updates the annotations for the UI service to create a NLB.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
