### PR TITLE
fix: Remove catalog in-memory db logging

### DIFF
--- a/src/catalog/repository/repository.go
+++ b/src/catalog/repository/repository.go
@@ -3,16 +3,12 @@ package repository
 import (
 	"context"
 	"fmt"
-	"log"
-	"os"
-	"time"
 
 	"github.com/aws-containers/retail-store-sample-app/catalog/config"
 	"github.com/aws-containers/retail-store-sample-app/catalog/model"
 	"gorm.io/driver/mysql"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
-	"gorm.io/gorm/logger"
 	"gorm.io/plugin/opentelemetry/tracing"
 )
 
@@ -41,7 +37,6 @@ func NewRepository(config config.DatabaseConfiguration) (CatalogRepository, erro
 		db, err = createMySQLDatabase(config)
 	} else {
 		fmt.Println("Using in-memory database")
-		
 		db, err = gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
 	}
 

--- a/src/catalog/repository/repository.go
+++ b/src/catalog/repository/repository.go
@@ -41,20 +41,8 @@ func NewRepository(config config.DatabaseConfiguration) (CatalogRepository, erro
 		db, err = createMySQLDatabase(config)
 	} else {
 		fmt.Println("Using in-memory database")
-		newLogger := logger.New(
-			log.New(os.Stdout, "\r\n", log.LstdFlags), // io writer
-			logger.Config{
-				SlowThreshold:             time.Second, // Slow SQL threshold
-				LogLevel:                  logger.Info, // Log level
-				IgnoreRecordNotFoundError: true,        // Ignore ErrRecordNotFound error for logger
-				ParameterizedQueries:      false,       // Don't include params in the SQL log
-				Colorful:                  false,       // Disable color
-			},
-		)
-
-		db, err = gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{
-			Logger: newLogger,
-		})
+		
+		db, err = gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
 	}
 
 	if err != nil {


### PR DESCRIPTION
*Issue #, if available:*

Catalog service logs SQL statements when running in-memory database mode

*Description of changes:*

Removes it


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
