### PR TITLE
Updated OTEL references in Order pom.xml files to be consistently on 2.17

### DIFF
--- a/src/orders/pom.xml
+++ b/src/orders/pom.xml
@@ -173,7 +173,7 @@
         <dependency>
             <groupId>io.opentelemetry.instrumentation</groupId>
             <artifactId>opentelemetry-aws-sdk-2.2-autoconfigure</artifactId>
-            <version>2.12.0-alpha</version>
+            <version>2.17.1-alpha</version>
             <scope>runtime</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
In Order service, changed version to 2.17.1 to align with other version reference in pom file

Issue #, if available:
The issue was that orders would fail in ECS when OTEL was enabled.

Description of changes:
The failure was caused by a SQL reference in the Order service. Cart and UI were updated just as house keeping tasks. No issue was occurring with those services.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.