### PR TITLE
fix: Use correct RabbitMQ credential field names

### DIFF
--- a/src/orders/chart/templates/rabbitmq-secret.yaml
+++ b/src/orders/chart/templates/rabbitmq-secret.yaml
@@ -5,9 +5,9 @@ metadata:
   name: {{ .Values.app.messaging.rabbitmq.secret.name }}
 data:
   {{- if .Values.app.messaging.rabbitmq.secret.username }}
-  SPRING_RABBITMQ_USERNAME: {{ .Values.app.messaging.rabbitmq.secret.username | b64enc | quote }}
+  RETAIL_ORDERS_MESSAGING_RABBITMQ_USERNAME: {{ .Values.app.messaging.rabbitmq.secret.username | b64enc | quote }}
   {{- end }}
   {{- if .Values.app.messaging.rabbitmq.secret.password }}
-  SPRING_RABBITMQ_PASSWORD: {{ .Values.app.messaging.rabbitmq.secret.password | b64enc | quote }}
+  RETAIL_ORDERS_MESSAGING_RABBITMQ_PASSWORD: {{ .Values.app.messaging.rabbitmq.secret.password | b64enc | quote }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
*Issue #, if available:* Fixes #893

*Description of changes:*

Updates the orders Helm chart to use the correct username and password variables for RabbitMQ


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
