### PR TITLE
fix: Improved CW Logging for ECS default deployment

### DIFF
--- a/terraform/ecs/default/variables.tf
+++ b/terraform/ecs/default/variables.tf
@@ -21,7 +21,7 @@ variable "container_image_overrides" {
 
 variable "opentelemetry_enabled" {
   type        = bool
-  default     = false
+  default     = true
   description = "Boolean value that enables OpenTelemetry."
 }
 

--- a/terraform/ecs/default/variables.tf
+++ b/terraform/ecs/default/variables.tf
@@ -21,7 +21,7 @@ variable "container_image_overrides" {
 
 variable "opentelemetry_enabled" {
   type        = bool
-  default     = true
+  default     = false
   description = "Boolean value that enables OpenTelemetry."
 }
 

--- a/terraform/lib/ecs/service/ecs.tf
+++ b/terraform/lib/ecs/service/ecs.tf
@@ -46,13 +46,13 @@ locals {
   }])
 
   base_container = {
-    name  = "application"
+    name  = "${var.service_name}-service"
     image = var.container_image
     portMappings = [
       {
         containerPort = 8080
         hostPort      = 8080
-        name          = "application"
+        name          = "${var.service_name}-service"
         protocol      = "tcp"
       }
     ]
@@ -157,7 +157,7 @@ resource "aws_ecs_service" "this" {
         port     = "80"
       }
       discovery_name = var.service_name
-      port_name      = "application"
+      port_name      = "${var.service_name}-service"
     }
   }
 
@@ -166,7 +166,7 @@ resource "aws_ecs_service" "this" {
 
     content {
       target_group_arn = var.alb_target_group_arn
-      container_name   = "application"
+      container_name   = "${var.service_name}-service"
       container_port   = 8080
     }
   }


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
In the ECS deployment, these changes made the container names unique so that they show up with service specific names in cloudwatch logs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
