### PR TITLE
feat: Support redis TLS for checkout service

### DIFF
--- a/src/checkout/README.md
+++ b/src/checkout/README.md
@@ -10,13 +10,13 @@ This service provides an API for storing customer data during the checkout proce
 
 The following environment variables are available for configuring the service:
 
-| Name                                    | Description                                                                                     | Default     |
-| --------------------------------------- | ----------------------------------------------------------------------------------------------- | ----------- |
-| `PORT`                                  | The port which the server will listen on                                                        | `8080`      |
-| `RETAIL_CHECKOUT_PERSISTENCE_PROVIDER`  | The persistence provider to use, can be `in-memory` or `redis`.                                 | `in-memory` |
-| `RETAIL_CHECKOUT_PERSISTENCE_REDIS_URL` | The endpoint of the Redis server used to store state, can start with `redis://` or `rediss://`. | `""`        |
-| `RETAIL_CHECKOUT_ENDPOINTS_ORDERS`      | The endpoint of the orders API. If empty uses a mock implementation                             | `""`        |
-| `RETAIL_CHECKOUT_SHIPPING_NAME_PREFIX`  | A string prefix that can be applied to the names of the shipping options                        | `""`        |
+| Name                                    | Description                                                              | Default     |
+| --------------------------------------- | ------------------------------------------------------------------------ | ----------- |
+| `PORT`                                  | The port which the server will listen on                                 | `8080`      |
+| `RETAIL_CHECKOUT_PERSISTENCE_PROVIDER`  | The persistence provider to use, can be `in-memory` or `redis`.          | `in-memory` |
+| `RETAIL_CHECKOUT_PERSISTENCE_REDIS_URL` | The endpoint of the Redis server used to store state.                    | `""`        |
+| `RETAIL_CHECKOUT_ENDPOINTS_ORDERS`      | The endpoint of the orders API. If empty uses a mock implementation      | `""`        |
+| `RETAIL_CHECKOUT_SHIPPING_NAME_PREFIX`  | A string prefix that can be applied to the names of the shipping options | `""`        |
 
 ## Endpoints
 

--- a/src/checkout/README.md
+++ b/src/checkout/README.md
@@ -10,13 +10,13 @@ This service provides an API for storing customer data during the checkout proce
 
 The following environment variables are available for configuring the service:
 
-| Name                                    | Description                                                              | Default     |
-| --------------------------------------- | ------------------------------------------------------------------------ | ----------- |
-| `PORT`                                  | The port which the server will listen on                                 | `8080`      |
-| `RETAIL_CHECKOUT_PERSISTENCE_PROVIDER`  | The persistence provider to use, can be `in-memory` or `redis`.          | `in-memory` |
-| `RETAIL_CHECKOUT_PERSISTENCE_REDIS_URL` | The endpoint of the Redis server used to store state.                    | `""`        |
-| `RETAIL_CHECKOUT_ENDPOINTS_ORDERS`      | The endpoint of the orders API. If empty uses a mock implementation      | `""`        |
-| `RETAIL_CHECKOUT_SHIPPING_NAME_PREFIX`  | A string prefix that can be applied to the names of the shipping options | `""`        |
+| Name                                    | Description                                                                                     | Default     |
+| --------------------------------------- | ----------------------------------------------------------------------------------------------- | ----------- |
+| `PORT`                                  | The port which the server will listen on                                                        | `8080`      |
+| `RETAIL_CHECKOUT_PERSISTENCE_PROVIDER`  | The persistence provider to use, can be `in-memory` or `redis`.                                 | `in-memory` |
+| `RETAIL_CHECKOUT_PERSISTENCE_REDIS_URL` | The endpoint of the Redis server used to store state, can start with `redis://` or `rediss://`. | `""`        |
+| `RETAIL_CHECKOUT_ENDPOINTS_ORDERS`      | The endpoint of the orders API. If empty uses a mock implementation                             | `""`        |
+| `RETAIL_CHECKOUT_SHIPPING_NAME_PREFIX`  | A string prefix that can be applied to the names of the shipping options                        | `""`        |
 
 ## Endpoints
 

--- a/src/checkout/chart/templates/configmap.yaml
+++ b/src/checkout/chart/templates/configmap.yaml
@@ -9,7 +9,8 @@ data:
   {{- if .Values.redis.create }}
   RETAIL_CHECKOUT_PERSISTENCE_REDIS_URL: redis://{{ include "checkout.redis.fullname" . }}:{{ .Values.redis.service.port }}
   {{- else }}
-  RETAIL_CHECKOUT_PERSISTENCE_REDIS_URL: {{ .Values.app.persistence.redis.endpoint }}
+  {{- $scheme := ternary "rediss" "redis" .Values.app.persistence.redis.tls }}
+  RETAIL_CHECKOUT_PERSISTENCE_REDIS_URL: {{ $scheme }}://{{ .Values.app.persistence.redis.endpoint }}
   {{- end }}
   {{- if .Values.app.endpoints.orders }}
   RETAIL_CHECKOUT_ENDPOINTS_ORDERS: {{ .Values.app.endpoints.orders }}

--- a/src/checkout/chart/templates/configmap.yaml
+++ b/src/checkout/chart/templates/configmap.yaml
@@ -9,7 +9,7 @@ data:
   {{- if .Values.redis.create }}
   RETAIL_CHECKOUT_PERSISTENCE_REDIS_URL: redis://{{ include "checkout.redis.fullname" . }}:{{ .Values.redis.service.port }}
   {{- else }}
-  RETAIL_CHECKOUT_PERSISTENCE_REDIS_URL: redis://{{ .Values.app.persistence.redis.endpoint }}
+  RETAIL_CHECKOUT_PERSISTENCE_REDIS_URL: {{ .Values.app.persistence.redis.endpoint }}
   {{- end }}
   {{- if .Values.app.endpoints.orders }}
   RETAIL_CHECKOUT_ENDPOINTS_ORDERS: {{ .Values.app.endpoints.orders }}

--- a/src/checkout/chart/values.yaml
+++ b/src/checkout/chart/values.yaml
@@ -77,6 +77,7 @@ app:
     provider: 'in-memory'
     redis:
       endpoint: ''
+      tls: false
 
   endpoints:
     orders: ''

--- a/src/checkout/package.json
+++ b/src/checkout/package.json
@@ -36,6 +36,7 @@
     "@willsoto/nestjs-prometheus": "^6.0.2",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
+    "ioredis": "^5.9.2",
     "nestjs-otel": "^7.0.0",
     "prom-client": "^15.1.3",
     "redis": "^5.5.6",

--- a/src/checkout/package.json
+++ b/src/checkout/package.json
@@ -39,7 +39,6 @@
     "ioredis": "^5.9.2",
     "nestjs-otel": "^7.0.0",
     "prom-client": "^15.1.3",
-    "redis": "^5.5.6",
     "reflect-metadata": "^0.2.2",
     "request": "^2.88.2",
     "rimraf": "^6.0.1",

--- a/src/checkout/src/checkout/checkout.module.ts
+++ b/src/checkout/src/checkout/checkout.module.ts
@@ -63,9 +63,9 @@ const repositoryProvider = {
     const logger = new Logger();
 
     if (persistenceProvider === 'redis') {
-      let tls = "";
+      let tls = '';
       if (redisReaderUrl.startsWith('rediss://')) {
-         tls = " with TLS"
+        tls = ' with TLS';
       }
       logger.log('Using redis persistence' + tls);
       repository = new RedisCheckoutRepository(redisUrl, redisReaderUrl);

--- a/src/checkout/src/checkout/checkout.module.ts
+++ b/src/checkout/src/checkout/checkout.module.ts
@@ -63,7 +63,11 @@ const repositoryProvider = {
     const logger = new Logger();
 
     if (persistenceProvider === 'redis') {
-      logger.log('Using redis persistence');
+      let tls = "";
+      if (redisReaderUrl.startsWith('rediss://')) {
+         tls = " with TLS"
+      }
+      logger.log('Using redis persistence' + tls);
       repository = new RedisCheckoutRepository(redisUrl, redisReaderUrl);
     } else {
       logger.log('Using in-memory persistence');

--- a/src/checkout/src/checkout/repositories/RedisCheckoutRepository.ts
+++ b/src/checkout/src/checkout/repositories/RedisCheckoutRepository.ts
@@ -18,40 +18,34 @@
 
 import { Injectable, OnModuleDestroy } from '@nestjs/common';
 import { ICheckoutRepository } from './ICheckoutRepository';
-import { createClient, RedisClientType } from 'redis';
+import { Redis } from 'ioredis';
 
 @Injectable()
 export class RedisCheckoutRepository
   implements ICheckoutRepository, OnModuleDestroy
 {
-  private _client: RedisClientType;
-  private _readClient: RedisClientType;
+  private _client: Redis;
+  private _readClient: Redis;
 
   constructor(
     private url: string,
     private readerUrl: string,
   ) {}
 
+  private async buildClient(url: string) {
+    return new Redis(url);
+  }
+
   async client() {
     if (!this._client) {
-      const config: any = { url: this.url };
-      if (this.url.startsWith('rediss://')) {
-        config.socket = { tls: true, rejectUnauthorized: false };
-      }
-      this._client = createClient(config);
-      await this._client.connect();
+      this._client = await this.buildClient(this.url);
     }
     return this._client;
   }
 
   async readClient() {
     if (!this._readClient) {
-      const config: any = { url: this.readerUrl };
-      if (this.readerUrl.startsWith('rediss://')) {
-        config.socket = { tls: true, rejectUnauthorized: false };
-      }
-      this._readClient = createClient(config);
-      await this._readClient.connect();
+      this._readClient = await this.buildClient(this.readerUrl);
     }
     return this._readClient;
   }
@@ -77,14 +71,12 @@ export class RedisCheckoutRepository
   async get(key: string): Promise<string> {
     const client = await this.readClient();
 
-    //@ts-expect-error TODO: Change from redis client upgrade
     return client.get(key);
   }
 
   async set(key: string, value: string): Promise<string> {
     const client = await this.client();
 
-    //@ts-expect-error TODO: Change from redis client upgrade
     return client.set(key, value);
   }
 

--- a/src/checkout/src/checkout/repositories/RedisCheckoutRepository.ts
+++ b/src/checkout/src/checkout/repositories/RedisCheckoutRepository.ts
@@ -34,7 +34,11 @@ export class RedisCheckoutRepository
 
   async client() {
     if (!this._client) {
-      this._client = createClient({ url: this.url });
+      const config: any = { url: this.url };
+      if (this.url.startsWith('rediss://')) {
+        config.socket = { tls: true, rejectUnauthorized: false };
+      }
+      this._client = createClient(config);
       await this._client.connect();
     }
     return this._client;
@@ -42,7 +46,11 @@ export class RedisCheckoutRepository
 
   async readClient() {
     if (!this._readClient) {
-      this._readClient = createClient({ url: this.readerUrl });
+      const config: any = { url: this.readerUrl };
+      if (this.readerUrl.startsWith('rediss://')) {
+        config.socket = { tls: true, rejectUnauthorized: false };
+      }
+      this._readClient = createClient(config);
       await this._readClient.connect();
     }
     return this._readClient;

--- a/src/checkout/yarn.lock
+++ b/src/checkout/yarn.lock
@@ -978,6 +978,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@ioredis/commands@npm:1.5.0":
+  version: 1.5.0
+  resolution: "@ioredis/commands@npm:1.5.0"
+  checksum: 10c0/2d192d967a21f0192e17310d27ead02b0bdd504e834c782714abe641190ebfb548ad307fd89fd2d80db97c462afdc69ab4a4383831ab64ce61fe92f130d8b466
+  languageName: node
+  linkType: hard
+
 "@isaacs/balanced-match@npm:^4.0.1":
   version: 4.0.1
   resolution: "@isaacs/balanced-match@npm:4.0.1"
@@ -4779,6 +4786,7 @@ __metadata:
     eslint: "npm:^9.30.1"
     eslint-config-prettier: "npm:^10.1.5"
     eslint-plugin-prettier: "npm:^5.5.1"
+    ioredis: "npm:^5.9.2"
     jest: "npm:30.0.4"
     nestjs-otel: "npm:^7.0.0"
     prettier: "npm:^3.6.2"
@@ -4931,7 +4939,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cluster-key-slot@npm:1.1.2":
+"cluster-key-slot@npm:1.1.2, cluster-key-slot@npm:^1.1.0":
   version: 1.1.2
   resolution: "cluster-key-slot@npm:1.1.2"
   checksum: 10c0/d7d39ca28a8786e9e801eeb8c770e3c3236a566625d7299a47bb71113fb2298ce1039596acb82590e598c52dbc9b1f088c8f587803e697cb58e1867a95ff94d3
@@ -5255,6 +5263,13 @@ __metadata:
   version: 1.0.0
   resolution: "delayed-stream@npm:1.0.0"
   checksum: 10c0/d758899da03392e6712f042bec80aa293bbe9e9ff1b2634baae6a360113e708b91326594c8a486d475c69d6259afb7efacdc3537bfcda1c6c648e390ce601b19
+  languageName: node
+  linkType: hard
+
+"denque@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "denque@npm:2.1.0"
+  checksum: 10c0/f9ef81aa0af9c6c614a727cb3bd13c5d7db2af1abf9e6352045b86e85873e629690f6222f4edd49d10e4ccf8f078bbeec0794fafaf61b659c0589d0c511ec363
   languageName: node
   linkType: hard
 
@@ -6664,6 +6679,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ioredis@npm:^5.9.2":
+  version: 5.9.2
+  resolution: "ioredis@npm:5.9.2"
+  dependencies:
+    "@ioredis/commands": "npm:1.5.0"
+    cluster-key-slot: "npm:^1.1.0"
+    debug: "npm:^4.3.4"
+    denque: "npm:^2.1.0"
+    lodash.defaults: "npm:^4.2.0"
+    lodash.isarguments: "npm:^3.1.0"
+    redis-errors: "npm:^1.2.0"
+    redis-parser: "npm:^3.0.0"
+    standard-as-callback: "npm:^2.1.0"
+  checksum: 10c0/9732a3adab56c63a0e76bd1a1c891e4201448c44ab31e7e9aee8e83005be07597a4969199593c0d59642fb3fcd64ce00e9a8fad6c92d80e648df20b4b2b184ce
+  languageName: node
+  linkType: hard
+
 "ip-address@npm:^10.0.1":
   version: 10.1.0
   resolution: "ip-address@npm:10.1.0"
@@ -7592,6 +7624,20 @@ __metadata:
   version: 4.3.0
   resolution: "lodash.camelcase@npm:4.3.0"
   checksum: 10c0/fcba15d21a458076dd309fce6b1b4bf611d84a0ec252cb92447c948c533ac250b95d2e00955801ebc367e5af5ed288b996d75d37d2035260a937008e14eaf432
+  languageName: node
+  linkType: hard
+
+"lodash.defaults@npm:^4.2.0":
+  version: 4.2.0
+  resolution: "lodash.defaults@npm:4.2.0"
+  checksum: 10c0/d5b77aeb702caa69b17be1358faece33a84497bcca814897383c58b28a2f8dfc381b1d9edbec239f8b425126a3bbe4916223da2a576bb0411c2cefd67df80707
+  languageName: node
+  linkType: hard
+
+"lodash.isarguments@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "lodash.isarguments@npm:3.1.0"
+  checksum: 10c0/5e8f95ba10975900a3920fb039a3f89a5a79359a1b5565e4e5b4310ed6ebe64011e31d402e34f577eca983a1fc01ff86c926e3cbe602e1ddfc858fdd353e62d8
   languageName: node
   linkType: hard
 
@@ -8838,6 +8884,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"redis-errors@npm:^1.0.0, redis-errors@npm:^1.2.0":
+  version: 1.2.0
+  resolution: "redis-errors@npm:1.2.0"
+  checksum: 10c0/5b316736e9f532d91a35bff631335137a4f974927bb2fb42bf8c2f18879173a211787db8ac4c3fde8f75ed6233eb0888e55d52510b5620e30d69d7d719c8b8a7
+  languageName: node
+  linkType: hard
+
+"redis-parser@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "redis-parser@npm:3.0.0"
+  dependencies:
+    redis-errors: "npm:^1.0.0"
+  checksum: 10c0/ee16ac4c7b2a60b1f42a2cdaee22b005bd4453eb2d0588b8a4939718997ae269da717434da5d570fe0b05030466eeb3f902a58cf2e8e1ca058bf6c9c596f632f
+  languageName: node
+  linkType: hard
+
 "redis@npm:^5.5.6":
   version: 5.5.6
   resolution: "redis@npm:5.5.6"
@@ -9395,6 +9457,13 @@ __metadata:
   dependencies:
     escape-string-regexp: "npm:^2.0.0"
   checksum: 10c0/651c9f87667e077584bbe848acaecc6049bc71979f1e9a46c7b920cad4431c388df0f51b8ad7cfd6eed3db97a2878d0fc8b3122979439ea8bac29c61c95eec8a
+  languageName: node
+  linkType: hard
+
+"standard-as-callback@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "standard-as-callback@npm:2.1.0"
+  checksum: 10c0/012677236e3d3fdc5689d29e64ea8a599331c4babe86956bf92fc5e127d53f85411c5536ee0079c52c43beb0026b5ce7aa1d834dd35dd026e82a15d1bcaead1f
   languageName: node
   linkType: hard
 

--- a/src/checkout/yarn.lock
+++ b/src/checkout/yarn.lock
@@ -2928,51 +2928,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@redis/bloom@npm:5.5.6":
-  version: 5.5.6
-  resolution: "@redis/bloom@npm:5.5.6"
-  peerDependencies:
-    "@redis/client": ^5.5.6
-  checksum: 10c0/1e50b2c94000b15e9555409692738e6acba796a469a0163e0abf2d2e0bc82304cd52dc4c2ad4f56bcc169030694f0777ab589548f7a47c55f09e5237a81bff95
-  languageName: node
-  linkType: hard
-
-"@redis/client@npm:5.5.6":
-  version: 5.5.6
-  resolution: "@redis/client@npm:5.5.6"
-  dependencies:
-    cluster-key-slot: "npm:1.1.2"
-  checksum: 10c0/92527c088410211aaa6038b38b4604bd930c9db3761603215b8ff025571f6ccdf6f93508c6de83b4e4caf76fedbf1e33ea0e72bfbe8a7bcff84d92f8b5d0af53
-  languageName: node
-  linkType: hard
-
-"@redis/json@npm:5.5.6":
-  version: 5.5.6
-  resolution: "@redis/json@npm:5.5.6"
-  peerDependencies:
-    "@redis/client": ^5.5.6
-  checksum: 10c0/142fc10510ab0392848662ea88244fa7d9cacbc8d746bd2dae4eb325227106a14e2f40256b790b2ded45c90bf9822fca2d5d4463e8e1a2176a1f6eff9f9666cb
-  languageName: node
-  linkType: hard
-
-"@redis/search@npm:5.5.6":
-  version: 5.5.6
-  resolution: "@redis/search@npm:5.5.6"
-  peerDependencies:
-    "@redis/client": ^5.5.6
-  checksum: 10c0/9f4516a23dcbb0bbcad3deecc9a39412bac24a1648eadccfae0c4710fc9f829728bbbe2774bfc2fe3bd8d61bd2e2c974183d3a37fa7c7f0a949a6c844da633c7
-  languageName: node
-  linkType: hard
-
-"@redis/time-series@npm:5.5.6":
-  version: 5.5.6
-  resolution: "@redis/time-series@npm:5.5.6"
-  peerDependencies:
-    "@redis/client": ^5.5.6
-  checksum: 10c0/7a30965bfdb104de383cd9ccf11e7850fdb45721c9159628b8b787d892871821df40ac6e041eee6695bbcf150e536ba9900a1b6e68485f75f10e8cbbb374fb27
-  languageName: node
-  linkType: hard
-
 "@scarf/scarf@npm:=1.4.0":
   version: 1.4.0
   resolution: "@scarf/scarf@npm:1.4.0"
@@ -4791,7 +4746,6 @@ __metadata:
     nestjs-otel: "npm:^7.0.0"
     prettier: "npm:^3.6.2"
     prom-client: "npm:^15.1.3"
-    redis: "npm:^5.5.6"
     reflect-metadata: "npm:^0.2.2"
     request: "npm:^2.88.2"
     rimraf: "npm:^6.0.1"
@@ -4939,7 +4893,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cluster-key-slot@npm:1.1.2, cluster-key-slot@npm:^1.1.0":
+"cluster-key-slot@npm:^1.1.0":
   version: 1.1.2
   resolution: "cluster-key-slot@npm:1.1.2"
   checksum: 10c0/d7d39ca28a8786e9e801eeb8c770e3c3236a566625d7299a47bb71113fb2298ce1039596acb82590e598c52dbc9b1f088c8f587803e697cb58e1867a95ff94d3
@@ -8897,19 +8851,6 @@ __metadata:
   dependencies:
     redis-errors: "npm:^1.0.0"
   checksum: 10c0/ee16ac4c7b2a60b1f42a2cdaee22b005bd4453eb2d0588b8a4939718997ae269da717434da5d570fe0b05030466eeb3f902a58cf2e8e1ca058bf6c9c596f632f
-  languageName: node
-  linkType: hard
-
-"redis@npm:^5.5.6":
-  version: 5.5.6
-  resolution: "redis@npm:5.5.6"
-  dependencies:
-    "@redis/bloom": "npm:5.5.6"
-    "@redis/client": "npm:5.5.6"
-    "@redis/json": "npm:5.5.6"
-    "@redis/search": "npm:5.5.6"
-    "@redis/time-series": "npm:5.5.6"
-  checksum: 10c0/e9a9f92545524dc33fba41b8a966a66b4c0ffd99944b9dd45931e2fdbc312f996361f96d1fe83321b32faed3da5aff40027e57f7515f423c9249cb44142fe543
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Closes: #108

*Description of changes:*
This PR provide support for TLS in redis connection, required when you want to use ElastiCache for checkout service.
No breaking change with previous helm chart deployment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
