### PR TITLE
feat: UI text response

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -49,6 +49,29 @@ This is a page in the UI component that displays information about the applicati
 
 The page can be found at `/topology`.
 
+### CLI-friendly ASCII response
+
+When the UI service root (`/`) is accessed without a browser — for example via `curl` or any other HTTP client that does not send `Accept: text/html` — it responds with a plain-text ASCII payload instead of HTML. This makes the service friendlier to explore from the command line and adds a bit of character to the application.
+
+```
+$ curl http://localhost:8080
+
+  ── INCOMING TRANSMISSION ──────────────────────── 23:47 UTC ──
+
+  TO   : FIELD AGENT
+  FROM : HEADQUARTERS, SUPPLIES DIVISION
+  RE   : GADGET REPOSITORY ACCESS
+
+  ───────────────────────────────────────────────────────────────
+
+  Agent — welcome to the repository. Your dossier is on file.
+  ...
+
+  ── END OF TRANSMISSION ─────────────────────── EYES ONLY ──────
+```
+
+The response is triggered when the root path `/` is requested without `text/html` in the `Accept` header. All other paths and browser requests are unaffected.
+
 ### Generative AI chat bot
 
 This feature provides a chat bot interface directly in the store UI which can be used to demonstrate basic LLM inference use-cases. It is works with Amazon Bedrock and OpenAI compatible endpoints via configuration properties.

--- a/src/orders/README.md
+++ b/src/orders/README.md
@@ -10,19 +10,19 @@ This service provides an API for storing orders. Data is stored in PostgreSQL.
 
 The following environment variables are available for configuring the service:
 
-| Name                                          | Description                                                                             | Default       |
-| --------------------------------------------- | --------------------------------------------------------------------------------------- | ------------- |
-| `PORT`                                        | The port which the server will listen on                                                | `8080`        |
-| `RETAIL_CHECKOUT_PERSISTENCE_PROVIDER`        | The persistence provider to use, can be `in-memory` or `postgres`.                      | `in-memory`   |
-| `RETAIL_ORDERS_PERSISTENCE_ENDPOINT`          | The postgres database endpoint.                                                         | `""`          |
-| `RETAIL_ORDERS_PERSISTENCE_NAME`              | The postgres database name                                                              | `""`          |
-| `RETAIL_ORDERS_PERSISTENCE_USERNAME`          | Username to authenticate with postgres database.                                        | `""`          |
-| `RETAIL_ORDERS_PERSISTENCE_PASSWORD`          | Password to authenticate with postgres database.                                        | `""`          |
-| `RETAIL_ORDERS_MESSAGING_PROVIDER`            | The messaging provider to use to publish events. Can be `in-memory`, `sqs`, `rabbitmq`. | `"in-memory"` |
-| `RETAIL_ORDERS_MESSAGING_SQS_TOPIC`           | The name of the SQS topic to publish events to (SQS messaging provider)                 | `""`          |
-| `RETAIL_ORDERS_MESSAGING_RABBITMQ_ADDRESSES`  | Endpoints for RabbitMQ messaging provider, format `host:port`                           | `""`          |
-| `RETAIL_ORDERS_MESSAGING_RABBITMQ_USERNAME`   | Username for RabbitMQ messaging provider                                                | `""`          |
-| `RETAIL_ORDERS_MESSAGING_RABBITMQ_PASSWORD`   | Password for RabbitMQ messaging provider                                                | `""`          |
+| Name                                         | Description                                                                             | Default       |
+| -------------------------------------------- | --------------------------------------------------------------------------------------- | ------------- |
+| `PORT`                                       | The port which the server will listen on                                                | `8080`        |
+| `RETAIL_CHECKOUT_PERSISTENCE_PROVIDER`       | The persistence provider to use, can be `in-memory` or `postgres`.                      | `in-memory`   |
+| `RETAIL_ORDERS_PERSISTENCE_ENDPOINT`         | The postgres database endpoint.                                                         | `""`          |
+| `RETAIL_ORDERS_PERSISTENCE_NAME`             | The postgres database name                                                              | `""`          |
+| `RETAIL_ORDERS_PERSISTENCE_USERNAME`         | Username to authenticate with postgres database.                                        | `""`          |
+| `RETAIL_ORDERS_PERSISTENCE_PASSWORD`         | Password to authenticate with postgres database.                                        | `""`          |
+| `RETAIL_ORDERS_MESSAGING_PROVIDER`           | The messaging provider to use to publish events. Can be `in-memory`, `sqs`, `rabbitmq`. | `"in-memory"` |
+| `RETAIL_ORDERS_MESSAGING_SQS_TOPIC`          | The name of the SQS topic to publish events to (SQS messaging provider)                 | `""`          |
+| `RETAIL_ORDERS_MESSAGING_RABBITMQ_ADDRESSES` | Endpoints for RabbitMQ messaging provider, format `host:port`                           | `""`          |
+| `RETAIL_ORDERS_MESSAGING_RABBITMQ_USERNAME`  | Username for RabbitMQ messaging provider                                                | `""`          |
+| `RETAIL_ORDERS_MESSAGING_RABBITMQ_PASSWORD`  | Password for RabbitMQ messaging provider                                                | `""`          |
 
 ## Endpoints
 

--- a/src/ui/src/main/java/com/amazon/sample/ui/web/util/AsciiArtWebFilter.java
+++ b/src/ui/src/main/java/com/amazon/sample/ui/web/util/AsciiArtWebFilter.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT-0
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.amazon.sample.ui.web.util;
+
+import jakarta.annotation.PostConstruct;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import org.springframework.web.server.WebFilter;
+import org.springframework.web.server.WebFilterChain;
+import reactor.core.publisher.Mono;
+
+@Component
+public class AsciiArtWebFilter implements WebFilter {
+
+  private byte[] asciiArtBytes;
+
+  @PostConstruct
+  public void init() throws IOException {
+    asciiArtBytes = new ClassPathResource(
+      "ascii-art.txt"
+    ).getContentAsByteArray();
+  }
+
+  @Override
+  public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+    String accept = exchange
+      .getRequest()
+      .getHeaders()
+      .getFirst(HttpHeaders.ACCEPT);
+
+    if (accept != null && accept.contains(MediaType.TEXT_HTML_VALUE)) {
+      return chain.filter(exchange);
+    }
+
+    exchange.getResponse().setStatusCode(HttpStatus.OK);
+    exchange
+      .getResponse()
+      .getHeaders()
+      .setContentType(new MediaType("text", "plain", StandardCharsets.UTF_8));
+
+    DataBuffer buffer = exchange
+      .getResponse()
+      .bufferFactory()
+      .wrap(asciiArtBytes);
+    return exchange.getResponse().writeWith(Mono.just(buffer));
+  }
+}

--- a/src/ui/src/main/java/com/amazon/sample/ui/web/util/AsciiArtWebFilter.java
+++ b/src/ui/src/main/java/com/amazon/sample/ui/web/util/AsciiArtWebFilter.java
@@ -46,12 +46,17 @@ public class AsciiArtWebFilter implements WebFilter {
 
   @Override
   public Mono<Void> filter(ServerWebExchange exchange, WebFilterChain chain) {
+    String path = exchange.getRequest().getPath().value();
     String accept = exchange
       .getRequest()
       .getHeaders()
       .getFirst(HttpHeaders.ACCEPT);
 
-    if (accept != null && accept.contains(MediaType.TEXT_HTML_VALUE)) {
+    boolean isRoot = "/".equals(path) || "".equals(path);
+    boolean wantsBrowser =
+      accept != null && accept.contains(MediaType.TEXT_HTML_VALUE);
+
+    if (!isRoot || wantsBrowser) {
       return chain.filter(exchange);
     }
 

--- a/src/ui/src/main/resources/ascii-art.txt
+++ b/src/ui/src/main/resources/ascii-art.txt
@@ -1,22 +1,25 @@
-╔══════════════════════════════════════════════════════════════╗
-║                  *** AGENT ACCESS ONLY ***                   ║
-║              HEADQUARTERS  ·  SUPPLIES DIVISION              ║
-╚══════════════════════════════════════════════════════════════╝
+  ── INCOMING TRANSMISSION ──────────────────────── 23:47 UTC ──
 
-  Welcome, Agent. Your mission, should you choose to accept it:
-  browse our gadget repository of the finest field equipment.
+  TO   : FIELD AGENT
+  FROM : HEADQUARTERS, SUPPLIES DIVISION
+  RE   : GADGET REPOSITORY ACCESS
 
-  ACTIVE AGENTS:       1,337
-  MISSIONS SUPPORTED:  42,069
-  GADGETS DEPLOYED:    99,999
-  ENEMY FOILED:        COUNTLESS
+  ───────────────────────────────────────────────────────────────
 
-  FIELD STATUS:  ●●●●●●●●●●  OPERATIONAL
-  STOCK LEVEL:   ●●●●●●●●○○  HIGH
+  Agent — welcome to the repository. Your dossier is on file.
 
-  To access the full gadget repository, open this URL in a browser.
-  This message will self-destruct in 5 seconds.
+  CURRENT STANDING:
+    Active Agents          1,337
+    Missions Supported    42,069
+    Gadgets Deployed      99,999
+    Enemies Foiled      COUNTLESS
 
-╔══════════════════════════════════════════════════════════════╗
-║     SECURE CHANNEL CLOSED  ·  GOOD LUCK OUT THERE, AGENT    ║
-╚══════════════════════════════════════════════════════════════╝
+  READINESS:
+    Field Status   ●●●●●●●●●●   OPERATIONAL
+    Stock Level    ●●●●●●●●○○   HIGH
+
+  A graphical interface is required to browse the full inventory.
+  Open this URL in a browser to proceed.
+
+  ───────────────────────────────────────────────────────────────
+  ── END OF TRANSMISSION ─────────────────────── EYES ONLY ──────

--- a/src/ui/src/main/resources/ascii-art.txt
+++ b/src/ui/src/main/resources/ascii-art.txt
@@ -1,0 +1,22 @@
+╔══════════════════════════════════════════════════════════════╗
+║                  *** AGENT ACCESS ONLY ***                   ║
+║              HEADQUARTERS  ·  SUPPLIES DIVISION              ║
+╚══════════════════════════════════════════════════════════════╝
+
+  Welcome, Agent. Your mission, should you choose to accept it:
+  browse our gadget repository of the finest field equipment.
+
+  ACTIVE AGENTS:       1,337
+  MISSIONS SUPPORTED:  42,069
+  GADGETS DEPLOYED:    99,999
+  ENEMY FOILED:        COUNTLESS
+
+  FIELD STATUS:  ●●●●●●●●●●  OPERATIONAL
+  STOCK LEVEL:   ●●●●●●●●○○  HIGH
+
+  To access the full gadget repository, open this URL in a browser.
+  This message will self-destruct in 5 seconds.
+
+╔══════════════════════════════════════════════════════════════╗
+║     SECURE CHANNEL CLOSED  ·  GOOD LUCK OUT THERE, AGENT    ║
+╚══════════════════════════════════════════════════════════════╝

--- a/src/ui/src/test/java/com/amazon/sample/ui/web/util/AsciiArtWebFilterTest.java
+++ b/src/ui/src/test/java/com/amazon/sample/ui/web/util/AsciiArtWebFilterTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT-0
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.amazon.sample.ui.web.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
+import org.springframework.mock.web.server.MockServerWebExchange;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+class AsciiArtWebFilterTest {
+
+  private AsciiArtWebFilter filter;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    filter = new AsciiArtWebFilter();
+    filter.init();
+  }
+
+  @Test
+  void withoutTextHtmlAccept_returnsAsciiPayload() {
+    MockServerWebExchange exchange = MockServerWebExchange.from(
+      MockServerHttpRequest.get("/").header(HttpHeaders.ACCEPT, "*/*").build()
+    );
+
+    AtomicBoolean chainCalled = new AtomicBoolean(false);
+
+    StepVerifier.create(
+      filter.filter(exchange, ex -> {
+        chainCalled.set(true);
+        return Mono.empty();
+      })
+    ).verifyComplete();
+
+    assertThat(chainCalled).isFalse();
+    assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.OK);
+    assertThat(exchange.getResponse().getHeaders().getContentType()).isEqualTo(
+      new org.springframework.http.MediaType(
+        "text",
+        "plain",
+        java.nio.charset.StandardCharsets.UTF_8
+      )
+    );
+
+    String body = exchange.getResponse().getBodyAsString().block();
+    assertThat(body).contains("AGENT ACCESS ONLY");
+    assertThat(body).contains("GOOD LUCK OUT THERE, AGENT");
+  }
+
+  @Test
+  void withTextHtmlAccept_delegatesToChain() {
+    MockServerWebExchange exchange = MockServerWebExchange.from(
+      MockServerHttpRequest.get("/")
+        .header(HttpHeaders.ACCEPT, MediaType.TEXT_HTML_VALUE)
+        .build()
+    );
+
+    AtomicBoolean chainCalled = new AtomicBoolean(false);
+
+    StepVerifier.create(
+      filter.filter(exchange, ex -> {
+        chainCalled.set(true);
+        return Mono.empty();
+      })
+    ).verifyComplete();
+
+    assertThat(chainCalled).isTrue();
+    assertThat(exchange.getResponse().getStatusCode()).isNull();
+  }
+}

--- a/src/ui/src/test/java/com/amazon/sample/ui/web/util/AsciiArtWebFilterTest.java
+++ b/src/ui/src/test/java/com/amazon/sample/ui/web/util/AsciiArtWebFilterTest.java
@@ -42,7 +42,7 @@ class AsciiArtWebFilterTest {
   }
 
   @Test
-  void withoutTextHtmlAccept_returnsAsciiPayload() {
+  void rootWithoutTextHtml_returnsAsciiPayload() {
     MockServerWebExchange exchange = MockServerWebExchange.from(
       MockServerHttpRequest.get("/").header(HttpHeaders.ACCEPT, "*/*").build()
     );
@@ -59,23 +59,40 @@ class AsciiArtWebFilterTest {
     assertThat(chainCalled).isFalse();
     assertThat(exchange.getResponse().getStatusCode()).isEqualTo(HttpStatus.OK);
     assertThat(exchange.getResponse().getHeaders().getContentType()).isEqualTo(
-      new org.springframework.http.MediaType(
-        "text",
-        "plain",
-        java.nio.charset.StandardCharsets.UTF_8
-      )
+      new MediaType("text", "plain", java.nio.charset.StandardCharsets.UTF_8)
     );
 
     String body = exchange.getResponse().getBodyAsString().block();
-    assertThat(body).contains("AGENT ACCESS ONLY");
-    assertThat(body).contains("GOOD LUCK OUT THERE, AGENT");
+    assertThat(body).contains("INCOMING TRANSMISSION");
+    assertThat(body).contains("END OF TRANSMISSION");
   }
 
   @Test
-  void withTextHtmlAccept_delegatesToChain() {
+  void rootWithTextHtml_delegatesToChain() {
     MockServerWebExchange exchange = MockServerWebExchange.from(
       MockServerHttpRequest.get("/")
         .header(HttpHeaders.ACCEPT, MediaType.TEXT_HTML_VALUE)
+        .build()
+    );
+
+    AtomicBoolean chainCalled = new AtomicBoolean(false);
+
+    StepVerifier.create(
+      filter.filter(exchange, ex -> {
+        chainCalled.set(true);
+        return Mono.empty();
+      })
+    ).verifyComplete();
+
+    assertThat(chainCalled).isTrue();
+    assertThat(exchange.getResponse().getStatusCode()).isNull();
+  }
+
+  @Test
+  void nonRootWithoutTextHtml_delegatesToChain() {
+    MockServerWebExchange exchange = MockServerWebExchange.from(
+      MockServerHttpRequest.get("/catalog")
+        .header(HttpHeaders.ACCEPT, "*/*")
         .build()
     );
 


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Currently if the UI is accessed through a tool like `curl` then the response is raw HTML, which isn't a good experience in a terminal.

This PR changes the UI component so the home page only renders HTML for `text/html` requests. Otherwise it will return a plain text response that is more suited for terminals etc.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
