### PR TITLE
fix: UI topology fallback to health endpoint

### DIFF
--- a/src/ui/src/main/java/com/amazon/sample/ui/web/TopologyController.java
+++ b/src/ui/src/main/java/com/amazon/sample/ui/web/TopologyController.java
@@ -20,51 +20,37 @@ package com.amazon.sample.ui.web;
 
 import com.amazon.sample.ui.config.EndpointProperties;
 import com.amazon.sample.ui.web.util.TopologyInformation;
-import com.amazon.sample.ui.web.util.TopologyStatus;
-import io.netty.channel.ChannelOption;
-import java.time.Duration;
-import java.util.Map;
+import com.amazon.sample.ui.web.util.TopologyService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
-import reactor.netty.http.client.HttpClient;
 
 @Controller
 @RequestMapping("/topology")
 @Slf4j
 public class TopologyController {
 
-  private static final int CONNECT_TIMEOUT = 1000;
-  private static final int RESPONSE_TIMEOUT = 1000;
-
   @Autowired
   private EndpointProperties endpoints;
 
+  @Autowired
+  private TopologyService topologyService;
+
   @GetMapping
   public String topology(Model model) {
-    HttpClient httpClient = HttpClient.create()
-      .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, CONNECT_TIMEOUT)
-      .responseTimeout(Duration.ofMillis(RESPONSE_TIMEOUT));
-
-    var webClient = WebClient.builder()
-      .clientConnector(new ReactorClientHttpConnector(httpClient))
-      .build();
-
     var topologyMap = Flux.merge(
-      getTopologyForService(webClient, "catalog", endpoints.getCatalog()),
-      getTopologyForService(webClient, "carts", endpoints.getCarts()),
-      getTopologyForService(webClient, "checkout", endpoints.getCheckout()),
-      getTopologyForService(webClient, "orders", endpoints.getOrders()),
-      getTopologyForService(
-        webClient,
+      topologyService.getTopologyForService("catalog", endpoints.getCatalog()),
+      topologyService.getTopologyForService("carts", endpoints.getCarts()),
+      topologyService.getTopologyForService(
+        "checkout",
+        endpoints.getCheckout()
+      ),
+      topologyService.getTopologyForService("orders", endpoints.getOrders()),
+      topologyService.getTopologyForService(
         "recommendations",
         endpoints.getRecommendations()
       )
@@ -73,45 +59,5 @@ public class TopologyController {
     model.addAttribute("topology", topologyMap);
 
     return "topology";
-  }
-
-  private Mono<TopologyInformation> getTopologyForService(
-    WebClient webClient,
-    String serviceName,
-    String endpoint
-  ) {
-    var topology = new TopologyInformation();
-    topology.setServiceName(serviceName);
-    topology.setEndpoint(endpoint);
-    topology.setStatus(TopologyStatus.NONE);
-
-    if (endpoint == null || endpoint.isEmpty()) {
-      return Mono.just(topology);
-    }
-
-    topology.setStatus(TopologyStatus.HEALTHY);
-
-    String topologyUrl = endpoint.endsWith("/")
-      ? endpoint + "topology"
-      : endpoint + "/topology";
-
-    return webClient
-      .get()
-      .uri(topologyUrl)
-      .retrieve()
-      .bodyToMono(new ParameterizedTypeReference<Map<String, String>>() {})
-      .map(metadata -> {
-        topology.setMetadata(metadata);
-        return topology;
-      })
-      .onErrorResume(e -> {
-        log.error(
-          "Error fetching topology for service {}: {}",
-          serviceName,
-          e.getMessage()
-        );
-        topology.setStatus(TopologyStatus.UNHEALTHY);
-        return Mono.just(topology);
-      });
   }
 }

--- a/src/ui/src/main/java/com/amazon/sample/ui/web/util/TopologyInformation.java
+++ b/src/ui/src/main/java/com/amazon/sample/ui/web/util/TopologyInformation.java
@@ -41,4 +41,8 @@ public class TopologyInformation {
   public boolean isNone() {
     return status == TopologyStatus.NONE;
   }
+
+  public boolean hasMetadata() {
+    return metadata != null && !metadata.isEmpty();
+  }
 }

--- a/src/ui/src/main/java/com/amazon/sample/ui/web/util/TopologyService.java
+++ b/src/ui/src/main/java/com/amazon/sample/ui/web/util/TopologyService.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT-0
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.amazon.sample.ui.web.util;
+
+import io.netty.channel.ChannelOption;
+import java.time.Duration;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import reactor.netty.http.client.HttpClient;
+
+@Service
+@Slf4j
+public class TopologyService {
+
+  private static final int CONNECT_TIMEOUT = 1000;
+  private static final int RESPONSE_TIMEOUT = 1000;
+
+  private final WebClient webClient;
+
+  @Autowired
+  public TopologyService(WebClient.Builder webClientBuilder) {
+    HttpClient httpClient = HttpClient.create()
+      .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, CONNECT_TIMEOUT)
+      .responseTimeout(Duration.ofMillis(RESPONSE_TIMEOUT));
+
+    this.webClient = webClientBuilder
+      .clientConnector(new ReactorClientHttpConnector(httpClient))
+      .build();
+  }
+
+  TopologyService(WebClient webClient) {
+    this.webClient = webClient;
+  }
+
+  public Mono<TopologyInformation> getTopologyForService(
+    String serviceName,
+    String endpoint
+  ) {
+    var topology = new TopologyInformation();
+    topology.setServiceName(serviceName);
+    topology.setEndpoint(endpoint);
+    topology.setStatus(TopologyStatus.NONE);
+
+    if (endpoint == null || endpoint.isEmpty()) {
+      return Mono.just(topology);
+    }
+
+    return fetchTopology(endpoint)
+      .map(metadata -> {
+        topology.setStatus(TopologyStatus.HEALTHY);
+        topology.setMetadata(metadata);
+        return topology;
+      })
+      .onErrorResume(topologyError -> {
+        log.debug(
+          "Topology endpoint unavailable for service {}: {} — falling back to health check",
+          serviceName,
+          topologyError.getMessage()
+        );
+        return checkHealth(endpoint).map(healthy -> {
+          topology.setStatus(
+            healthy ? TopologyStatus.HEALTHY : TopologyStatus.UNHEALTHY
+          );
+          if (!healthy) {
+            log.warn(
+              "Health check failed for service {} at {}",
+              serviceName,
+              endpoint
+            );
+          }
+          return topology;
+        });
+      });
+  }
+
+  private Mono<Map<String, String>> fetchTopology(String endpoint) {
+    return webClient
+      .get()
+      .uri(joinPath(endpoint, "topology"))
+      .retrieve()
+      .bodyToMono(new ParameterizedTypeReference<Map<String, String>>() {});
+  }
+
+  private Mono<Boolean> checkHealth(String endpoint) {
+    return probeHealth(joinPath(endpoint, "health")).flatMap(ok ->
+      ok ? Mono.just(true) : probeHealth(joinPath(endpoint, "actuator/health"))
+    );
+  }
+
+  private Mono<Boolean> probeHealth(String url) {
+    return webClient
+      .get()
+      .uri(url)
+      .retrieve()
+      .toBodilessEntity()
+      .map(response -> response.getStatusCode().is2xxSuccessful())
+      .onErrorReturn(false);
+  }
+
+  private String joinPath(String endpoint, String path) {
+    return endpoint.endsWith("/") ? endpoint + path : endpoint + "/" + path;
+  }
+}

--- a/src/ui/src/main/resources/templates/topology.html
+++ b/src/ui/src/main/resources/templates/topology.html
@@ -40,7 +40,7 @@
               th:text="${info.endpoint}"
             ></div>
           </div>
-          <div class="grid grid-cols-3 gap-6">
+          <div class="grid grid-cols-3 gap-6" th:if="${info.hasMetadata()}">
             <div>
               <div class="text-xs text-gray-500">Persistence Provider</div>
               <div
@@ -91,7 +91,7 @@
               th:text="${info.endpoint}"
             ></div>
           </div>
-          <div class="grid grid-cols-3 gap-6">
+          <div class="grid grid-cols-3 gap-6" th:if="${info.hasMetadata()}">
             <div>
               <div class="text-xs text-gray-500">Persistence Provider</div>
               <div
@@ -152,7 +152,7 @@
               th:text="${info.endpoint}"
             ></div>
           </div>
-          <div class="grid grid-cols-3 gap-6">
+          <div class="grid grid-cols-3 gap-6" th:if="${info.hasMetadata()}">
             <div>
               <div class="text-xs text-gray-500">Persistence Provider</div>
               <div
@@ -234,7 +234,7 @@
               th:text="${info.endpoint}"
             ></div>
           </div>
-          <div class="grid grid-cols-3 gap-6">
+          <div class="grid grid-cols-3 gap-6" th:if="${info.hasMetadata()}">
             <div>
               <div class="text-xs text-gray-500">Persistence Provider</div>
               <div

--- a/src/ui/src/test/java/com/amazon/sample/ui/web/util/TopologyServiceTest.java
+++ b/src/ui/src/test/java/com/amazon/sample/ui/web/util/TopologyServiceTest.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: MIT-0
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this
+ * software and associated documentation files (the "Software"), to deal in the Software
+ * without restriction, including without limitation the rights to use, copy, modify,
+ * merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+ * INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+ * PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ * OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package com.amazon.sample.ui.web.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.reactive.function.client.ClientRequest;
+import org.springframework.web.reactive.function.client.ClientResponse;
+import org.springframework.web.reactive.function.client.ExchangeFunction;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+class TopologyServiceTest {
+
+  private static final String ENDPOINT = "http://service.test";
+
+  @Test
+  void returnsNoneWhenEndpointIsNull() {
+    var recorder = new RequestRecorder(req -> response(HttpStatus.OK, ""));
+    var service = new TopologyService(buildClient(recorder));
+
+    StepVerifier.create(service.getTopologyForService("svc", null))
+      .assertNext(info -> {
+        assertThat(info.getStatus()).isEqualTo(TopologyStatus.NONE);
+        assertThat(info.getServiceName()).isEqualTo("svc");
+      })
+      .verifyComplete();
+
+    assertThat(recorder.requestedPaths).isEmpty();
+  }
+
+  @Test
+  void returnsNoneWhenEndpointIsEmpty() {
+    var recorder = new RequestRecorder(req -> response(HttpStatus.OK, ""));
+    var service = new TopologyService(buildClient(recorder));
+
+    StepVerifier.create(service.getTopologyForService("svc", ""))
+      .assertNext(info ->
+        assertThat(info.getStatus()).isEqualTo(TopologyStatus.NONE)
+      )
+      .verifyComplete();
+
+    assertThat(recorder.requestedPaths).isEmpty();
+  }
+
+  @Test
+  void healthyWithMetadataWhenTopologySucceeds() {
+    var recorder = new RequestRecorder(req ->
+      jsonResponse(
+        HttpStatus.OK,
+        "{\"persistenceProvider\":\"mysql\",\"databaseEndpoint\":\"db:3306\"}"
+      )
+    );
+    var service = new TopologyService(buildClient(recorder));
+
+    StepVerifier.create(service.getTopologyForService("svc", ENDPOINT))
+      .assertNext(info -> {
+        assertThat(info.getStatus()).isEqualTo(TopologyStatus.HEALTHY);
+        assertThat(info.hasMetadata()).isTrue();
+        assertThat(info.getMetadata())
+          .containsEntry("persistenceProvider", "mysql")
+          .containsEntry("databaseEndpoint", "db:3306");
+      })
+      .verifyComplete();
+
+    assertThat(recorder.requestedPaths).containsExactly("/topology");
+  }
+
+  @Test
+  void fallsBackToHealthWhenTopologyFails() {
+    var recorder = new RequestRecorder(req -> {
+      String path = req.url().getPath();
+      if (path.equals("/topology")) {
+        return response(HttpStatus.INTERNAL_SERVER_ERROR, "");
+      }
+      if (path.equals("/health")) {
+        return response(HttpStatus.OK, "");
+      }
+      return response(HttpStatus.NOT_FOUND, "");
+    });
+    var service = new TopologyService(buildClient(recorder));
+
+    StepVerifier.create(service.getTopologyForService("svc", ENDPOINT))
+      .assertNext(info -> {
+        assertThat(info.getStatus()).isEqualTo(TopologyStatus.HEALTHY);
+        assertThat(info.hasMetadata()).isFalse();
+      })
+      .verifyComplete();
+
+    assertThat(recorder.requestedPaths).containsExactly("/topology", "/health");
+  }
+
+  @Test
+  void fallsBackToActuatorHealthWhenHealthIsMissing() {
+    var recorder = new RequestRecorder(req -> {
+      String path = req.url().getPath();
+      if (path.equals("/topology") || path.equals("/health")) {
+        return response(HttpStatus.NOT_FOUND, "");
+      }
+      if (path.equals("/actuator/health")) {
+        return response(HttpStatus.OK, "");
+      }
+      return response(HttpStatus.NOT_FOUND, "");
+    });
+    var service = new TopologyService(buildClient(recorder));
+
+    StepVerifier.create(service.getTopologyForService("svc", ENDPOINT))
+      .assertNext(info -> {
+        assertThat(info.getStatus()).isEqualTo(TopologyStatus.HEALTHY);
+        assertThat(info.hasMetadata()).isFalse();
+      })
+      .verifyComplete();
+
+    assertThat(recorder.requestedPaths).containsExactly(
+      "/topology",
+      "/health",
+      "/actuator/health"
+    );
+  }
+
+  @Test
+  void unhealthyWhenTopologyAndAllHealthProbesFail() {
+    var recorder = new RequestRecorder(req ->
+      response(HttpStatus.INTERNAL_SERVER_ERROR, "")
+    );
+    var service = new TopologyService(buildClient(recorder));
+
+    StepVerifier.create(service.getTopologyForService("svc", ENDPOINT))
+      .assertNext(info -> {
+        assertThat(info.getStatus()).isEqualTo(TopologyStatus.UNHEALTHY);
+        assertThat(info.hasMetadata()).isFalse();
+      })
+      .verifyComplete();
+
+    assertThat(recorder.requestedPaths).containsExactly(
+      "/topology",
+      "/health",
+      "/actuator/health"
+    );
+  }
+
+  @Test
+  void joinsPathCorrectlyWhenEndpointHasTrailingSlash() {
+    var recorder = new RequestRecorder(req ->
+      jsonResponse(HttpStatus.OK, "{\"key\":\"value\"}")
+    );
+    var service = new TopologyService(buildClient(recorder));
+
+    StepVerifier.create(service.getTopologyForService("svc", ENDPOINT + "/"))
+      .assertNext(info ->
+        assertThat(info.getStatus()).isEqualTo(TopologyStatus.HEALTHY)
+      )
+      .verifyComplete();
+
+    assertThat(recorder.requestedPaths).containsExactly("/topology");
+  }
+
+  private WebClient buildClient(ExchangeFunction exchange) {
+    return WebClient.builder().exchangeFunction(exchange).build();
+  }
+
+  private static Mono<ClientResponse> response(HttpStatus status, String body) {
+    return Mono.just(
+      ClientResponse.create(status).body(body == null ? "" : body).build()
+    );
+  }
+
+  private static Mono<ClientResponse> jsonResponse(
+    HttpStatus status,
+    String body
+  ) {
+    return Mono.just(
+      ClientResponse.create(status)
+        .header("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+        .body(body)
+        .build()
+    );
+  }
+
+  private static class RequestRecorder implements ExchangeFunction {
+
+    final List<String> requestedPaths = new ArrayList<>();
+    private final Function<ClientRequest, Mono<ClientResponse>> handler;
+
+    RequestRecorder(Function<ClientRequest, Mono<ClientResponse>> handler) {
+      this.handler = handler;
+    }
+
+    @Override
+    public Mono<ClientResponse> exchange(ClientRequest request) {
+      requestedPaths.add(request.url().getPath());
+      return handler.apply(request);
+    }
+  }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Currently the UI /topology endpoint shows 'Unhealthy' if a component does not provide its own /topology endpoint for richer metadata. For situations where implementing simpler components as part of a workshop or other exercise the requirement to implement /topology in a component will seem a little strange.

This PR changes the logic of the UI topology building so it:

1. First checks /topology
2. If that fails check /health and /actuator/health

If (2) succeeds the component is marked healthy but will show no extra metadata.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
