### PR TITLE
fix(cart): replace no-op DynamoDB healthcheck with curl readiness probe and fail-fast on table creation

### DIFF
--- a/src/cart/docker-compose.yml
+++ b/src/cart/docker-compose.yml
@@ -49,7 +49,8 @@ services:
     tmpfs:
       - /tmp:rw,noexec,nosuid
     healthcheck:
-      test: ["CMD-SHELL", "exit 0"]
+      test: ["CMD-SHELL", "curl -sf http://localhost:8000/shell/ > /dev/null 2>&1 || exit 1"]
       interval: 5s
       timeout: 15s
-      retries: 3
+      retries: 5
+      start_period: 10s

--- a/src/cart/src/main/java/com/amazon/sample/carts/services/DynamoDBCartService.java
+++ b/src/cart/src/main/java/com/amazon/sample/carts/services/DynamoDBCartService.java
@@ -69,7 +69,11 @@ public class DynamoDBCartService
 
   @Override
   public void onApplicationEvent(final @NonNull ApplicationReadyEvent event) {
-    this.items("test");
+    try {
+      this.items("test");
+    } catch (Exception e) {
+      log.warn("Failed to verify DynamoDB table on startup: {}", e.getMessage());
+    }
   }
 
   @PostConstruct
@@ -80,28 +84,33 @@ public class DynamoDBCartService
           DeleteTableRequest.builder().tableName(this.tableName).build()
         );
       } catch (ResourceNotFoundException rnfe) {
-        log.warn("Dynamo table not found");
+        log.info("Dynamo table {} not found (expected on first startup)", this.tableName);
       }
 
-      this.table.createTable(builder ->
-          builder
-            .globalSecondaryIndices(builder3 ->
-              builder3
-                .indexName("idx_global_customerId")
-                .projection(builder2 ->
-                  builder2.projectionType(ProjectionType.ALL)
-                )
-                .provisionedThroughput(builder4 ->
-                  builder4.writeCapacityUnits(1L).readCapacityUnits(1L)
-                )
-            )
-            .provisionedThroughput(b ->
-              b.readCapacityUnits(1L).writeCapacityUnits(1L).build()
-            )
+      try {
+        this.table.createTable(builder ->
+            builder
+              .globalSecondaryIndices(builder3 ->
+                builder3
+                  .indexName("idx_global_customerId")
+                  .projection(builder2 ->
+                    builder2.projectionType(ProjectionType.ALL)
+                  )
+                  .provisionedThroughput(builder4 ->
+                    builder4.writeCapacityUnits(1L).readCapacityUnits(1L)
+                  )
+              )
+              .provisionedThroughput(b ->
+                b.readCapacityUnits(1L).writeCapacityUnits(1L).build()
+              )
         );
 
-      this.dynamoDBClient.waiter()
-        .waitUntilTableExists(b -> b.tableName(this.tableName));
+        this.dynamoDBClient.waiter()
+          .waitUntilTableExists(b -> b.tableName(this.tableName));
+      } catch (Exception e) {
+        log.error("Failed to create DynamoDB table {}", this.tableName, e);
+        throw new RuntimeException("Failed to create DynamoDB table", e);
+      }
     }
   }
 


### PR DESCRIPTION
## Root Cause

The `carts-db` service in `src/cart/docker-compose.yml` had a no-op healthcheck (`exit 0`), making `depends_on: condition: service_healthy` meaningless. The cart container started before DynamoDB Local was actually ready, causing `@PostConstruct init()` to fail creating the `Items` table silently. Subsequent writes threw `ResourceNotFoundException`.

## Changes

### `src/cart/docker-compose.yml`
- Replaced `exit 0` healthcheck with `curl -sf http://localhost:8000/shell/` (DynamoDB Local's built-in web shell — returns 200 only when the service is ready to accept API calls)
- Added `start_period: 10s` and increased `retries` to 5 for startup latency tolerance

### `src/cart/.../DynamoDBCartService.java`
- Wrapped `@PostConstruct createTable()` in try-catch that throws `RuntimeException` to fail fast (instead of silently logging WARN and continuing without a table)
- Wrapped `onApplicationEvent` verification query in try-catch with WARN log to prevent startup failure on transient table absence
- Changed `deleteTable()` `ResourceNotFoundException` catch from WARN to INFO (expected on first startup, not a warning)

## Verification
- [x] Structural checks passed (no-op healthcheck removed, curl probe present, createTable has fail-fast, onApplicationEvent has try-catch)
- [ ] Runtime verification requires `docker compose up -d` with the fix applied