### PR TITLE
fix(terraform): align Helm provider version for EKS

### DIFF
--- a/terraform/eks/default/versions.tf
+++ b/terraform/eks/default/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.17.0"
+      version = "~> 3.0"
     }
     kubectl = {
       source  = "gavinbunney/kubectl"

--- a/terraform/eks/default/versions.tf
+++ b/terraform/eks/default/versions.tf
@@ -51,7 +51,7 @@ provider "kubectl" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = module.retail_app_eks.cluster_endpoint
     token                  = data.aws_eks_cluster_auth.this.token
     cluster_ca_certificate = base64decode(module.retail_app_eks.cluster_certificate_authority_data)

--- a/terraform/eks/minimal/versions.tf
+++ b/terraform/eks/minimal/versions.tf
@@ -35,7 +35,7 @@ provider "kubernetes" {
 }
 
 provider "helm" {
-  kubernetes {
+  kubernetes = {
     host                   = module.retail_app_eks.cluster_endpoint
     token                  = data.aws_eks_cluster_auth.this.token
     cluster_ca_certificate = base64decode(module.retail_app_eks.cluster_certificate_authority_data)

--- a/terraform/eks/minimal/versions.tf
+++ b/terraform/eks/minimal/versions.tf
@@ -12,7 +12,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.17.0"
+      version = "~> 3.0"
     }
   }
 }

--- a/terraform/lib/eks/istio.tf
+++ b/terraform/lib/eks/istio.tf
@@ -15,10 +15,10 @@ resource "helm_release" "istio_base" {
   namespace  = kubernetes_namespace_v1.istio[0].metadata[0].name
   wait       = true
 
-  set {
+  set = [{
     name  = "defaultRevision"
     value = "default"
-  }
+  }]
 }
 
 resource "helm_release" "istiod" {
@@ -34,10 +34,10 @@ resource "helm_release" "istiod" {
   namespace  = kubernetes_namespace_v1.istio[0].metadata[0].name
   wait       = true
 
-  set {
+  set = [{
     name  = "defaultRevision"
     value = "default"
-  }
+  }]
 }
 
 resource "kubernetes_namespace_v1" "istio_ingress" {

--- a/terraform/lib/eks/versions.tf
+++ b/terraform/lib/eks/versions.tf
@@ -13,7 +13,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.17.0"
+      version = "~> 3.0"
     }
   }
 }


### PR DESCRIPTION

## Issue
No issue number was created for this change.

## Description of changes
This PR fixes a Terraform initialization failure in the EKS configuration.

When running `terraform init`, Terraform failed because the Helm provider version was pinned to an older constraint that no longer matched the current dependency chain. The configuration was set to `hashicorp/helm` `~> 2.17.0`, which caused provider resolution to fail.

### What changed
- Updated the Helm provider version constraint from `~> 2.17.0` to `~> 3.0` in the relevant Terraform files.
- This allows Terraform to resolve and install a compatible Helm provider version successfully.

### Files updated
- versions.tf
- versions.tf
- versions.tf

### Verification
- Ran `terraform init`
- Confirmed Terraform completed successfully with: “Terraform has been successfully initialized!”


- “By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.”

<img width="985" height="159" alt="Screenshot 2026-07-14 at 9 36 06 PM" src="https://github.com/user-attachments/assets/9a1705b6-6d06-445c-8698-625ca2d27ad6" />

<img width="768" height="533" alt="Screenshot 2026-07-14 at 9 39 48 PM" src="https://github.com/user-attachments/assets/92d10019-2977-4cab-a266-84b854e3f739" />
