### PR TITLE
docs: fix deployment instructions in terraform/{eks,apprunner}/{minimal,default}/README.md

### DIFF
--- a/terraform/apprunner/default/README.md
+++ b/terraform/apprunner/default/README.md
@@ -22,7 +22,7 @@ Pre-requisites for this are:
 After cloning this repository run the following commands:
 
 ```shell
-cd terraform/apprunner
+cd terraform/apprunner/default
 
 terraform init
 terraform plan

--- a/terraform/eks/default/README.md
+++ b/terraform/eks/default/README.md
@@ -23,7 +23,7 @@ Pre-requisites for this are:
 After cloning this repository run the following commands:
 
 ```shell
-cd terraform/eks
+cd terraform/eks/default
 
 terraform init
 terraform plan

--- a/terraform/eks/minimal/README.md
+++ b/terraform/eks/minimal/README.md
@@ -19,7 +19,7 @@ Pre-requisites for this are:
 After cloning this repository run the following commands:
 
 ```shell
-cd terraform/eks
+cd terraform/eks/minimal
 
 terraform init
 terraform plan


### PR DESCRIPTION
With the new `minimal` and `default` directories in the different deployment options, I noticed the `cd` command in `eks` and in `apprunner` were not updated.

*Description of changes:* I added the new directory paths to the deployment instructions in README.md in each of the deployment options.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
